### PR TITLE
Fame table fix

### DIFF
--- a/server/area/helpfile.are
+++ b/server/area/helpfile.are
@@ -891,7 +891,7 @@ Kick an opponent during battle, causing some damage.
 ~
 
 0 'KNIFE TOSS'~
-Syntax: KNIFE TOSS <target>
+Syntax: KNIFE <target>
 
 Thieves are good with small throwing knives and can toss them at enemies during combat doing some damage.
 ~

--- a/server/src/fight.c
+++ b/server/src/fight.c
@@ -5132,6 +5132,16 @@ void do_flying_headbutt (CHAR_DATA *ch, char *argument)
         one_argument(argument,arg);
         victim = ch->fighting;
 
+        /*
+         * Moved to before the head/huge checks
+         */
+
+        if (arg[0] != '\0' && !(victim = get_char_room(ch, arg)))
+        {
+                send_to_char("They aren't here.\n\r",ch);
+                return;
+        }
+
         if (!HAS_HEAD (victim))
         {
                 act ("$C has no head for you to butt!", ch, NULL, victim, TO_CHAR);
@@ -5141,12 +5151,6 @@ void do_flying_headbutt (CHAR_DATA *ch, char *argument)
         if (IS_HUGE (victim))
         {
                 act ("$C is too large for you to headbutt!", ch, NULL, victim, TO_CHAR);
-                return;
-        }
-
-        if (arg[0] != '\0' && !(victim = get_char_room(ch, arg)))
-        {
-                send_to_char("They aren't here.\n\r",ch);
                 return;
         }
 

--- a/server/src/table.c
+++ b/server/src/table.c
@@ -46,7 +46,7 @@ void check_fame_table (CHAR_DATA *ch)
 {
         int prev = 0;
         int in = 0;
-        int i;
+        int i = 0;
         char buf[ MAX_STRING_LENGTH ];
         char buf1[ MAX_STRING_LENGTH ];
         
@@ -64,16 +64,32 @@ void check_fame_table (CHAR_DATA *ch)
         
         if (!in && (ch->pcdata->fame < fame_table[FAME_TABLE_LENGTH - 1].fame))
                 return;
-        
+
         if (!in) 
         {
-                for (i = FAME_TABLE_LENGTH - 1;  
-                     (fame_table[i - 1].fame <= ch->pcdata->fame && i != 0);
-                     i--)
+                for (i = FAME_TABLE_LENGTH - 1; (fame_table[i - 1].fame <= ch->pcdata->fame); i--)
                 {
                         strncpy(fame_table[i].name, fame_table[i - 1].name, sizeof(fame_table[i].name));
                         fame_table[i].fame = fame_table[i - 1].fame;
+
+                        /*
+                         * Shade 11.3.22
+                         *
+                         * Something about this has changed - the table appears to copy correctly but i gets decremented one time too many meaning players are promoted to the 0th position
+                         * 
+                         * Pretty sure it'll also mess up the fame table and character "1" will be kind of everywhere
+                         */
+
+                        if (i == 1) 
+                        {
+                                /* Might just log this for a bit; just in case */
+                                sprintf(buf, "Promoting %s to 1st position in fame table", ch->name);
+                                log_string(buf);  
+                                i = 0;
+                                break;
+                        }
                 }
+                                
                 strncpy(fame_table[i].name, ch->name, sizeof(fame_table[i].name));
                 fame_table[i].fame = ch->pcdata->fame;
                 
@@ -83,14 +99,16 @@ void check_fame_table (CHAR_DATA *ch)
                  */
                 if (i < FAME_TABLE_LENGTH_PRINT) 
                 {
+                     
                         sprintf(buf, "You are now ranked %d%s amongst famous mortals.\n\r", 
                                 i + 1,
-                                number_suffix(i+1));
+                                number_suffix(i + 1));
                         send_to_char( buf, ch );
+                        
                         sprintf(buf, "%s is now ranked number %d%s amongst famous mortals.",
                                 ch->name, 
                                 i + 1,
-                                number_suffix(i+1));
+                                number_suffix(i + 1));
                         do_info(ch, buf);
                 }
         }
@@ -151,6 +169,7 @@ void check_fame_table (CHAR_DATA *ch)
                 if (ch->desc->connected == CON_PLAYING
                     && prev < FAME_TABLE_LENGTH_PRINT && ((i && i != prev) || !i)) 
                 {
+
                         sprintf(buf, "You are now ranked %d%s amongst famous mortals.\n\r", 
                                 prev + 1,
                                 number_suffix(prev+1));


### PR DESCRIPTION
Help file fix for KNIFE TOSS

Flying Headbutt fix - size test is before a target is defined

Fame table fix - promotions to the top of the table are failing "0th position".  Unclear why, explicitly tested for various things but then just went with checking for i == 1 because that's the last copy (copy moves i - 1 to i).