### PR TITLE
Added "autolevel" config toggle.

### DIFF
--- a/server/area/helpfile.are
+++ b/server/area/helpfile.are
@@ -191,7 +191,7 @@ Dragons Domain version 4.2020
 
 -1 MOTD~
 {x
-    [22 February 2022]
+    [16 March 2022]
     ---------------------------------------------------------------------
     {WDragons Domain 4.0{x
 
@@ -203,6 +203,12 @@ Dragons Domain version 4.2020
     our website which has a FAQ at {Yhttps://smihilist.com/dd4/web/{x or look
     for players with a {CGuide{x flag.  We're also running a Discord server
     at {Yhttps://discord.gg/aGzmAWmXYb{x if you'd like to jump in and say hi!
+
+    {WNew config option in: AUTOLEVEL{x (see 'help autolevel'). {RWARNING, 
+    VERY IMPORTANT READ THIS:{x Unless your character is new, you will need to
+    type "autolevel" and turn the feature ON after logging in the first time
+    you see this message in order to gain levels.  You should only have to do 
+    this once!
 
 To Enter the Dragons Domain press <Return>.
 ~
@@ -277,10 +283,11 @@ been added;
 - Chaos Blast for Satanists
 - Detect Curse for those with Divination
 - Knife Toss for Thieves
+- New config option: "AUTOLEVEL"
 
 Refer appropriate HELP entries.
 
-We're also trying to tidy up a lot of minor issues, formating, spelling, 
+We're also trying to tidy up a lot of minor issues, formatting, spelling, 
 links in areas, and things like that.  
 
 There are skills that open up which you then can't practice at that 
@@ -1104,10 +1111,11 @@ service.
   wear wield hold                       spells affect practice train whois
   list buy sell value donate
   recite brandish quaff zap           {WConfiguration:{x
-  {wlock unlock open close pick bash      config channels password autocoin
+  {wlock unlock open close pick bash    config channels password autocoin
   inventory equipment look compare      autoloot autosac autoexit autowield
-  eat drink fill smear                  blank prompt color ansi pagelength
-                                        attacks gag brief notell quiet
+  eat drink fill smear                  autolevel blank prompt color ansi 
+                                        pagelength attacks gag brief notell
+                                        quiet 
 {WCommunication:{x
   {wsay chat shout answer music yell    {WCombat:{x
   {wgtell clantalk tell reply review      kill murder flee wimpy cast
@@ -1504,6 +1512,7 @@ The options are:
     AUTOSAC   You automatically sacrifice corpses.
     AUTOCOIN  You automatically take coin from corpses.
     AUTOWIELD You automatically wield weapons picked up when in combat.
+    AUTOLEVEL You automatically level when you gain enough experience.
     BLANK     You have a blank line before your prompt.
     BRIEF     You see brief descriptions only.
     COMBINE   You see object lists in combined format.
@@ -1550,6 +1559,16 @@ AUTOLOOT toggles your ability to automatically loot corpses after you deal
 the final blow.
 
 See CONFIGURE to find out which toggle is on and which is off.
+~
+
+0 AUTOLEVEL~
+Syntax: autolevel
+
+AUTOLEVEL toggles your ability to automatically level when you gain sufficient
+experience.  It is ON by default for new characters.  With it OFF you will not 
+be able to gain levels until you turn it back ON.
+
+Type CONFIG or SCORE to find out if it's currently ON or OFF.
 ~
 
 0 AUTOSAC~

--- a/server/src/act_info.c
+++ b/server/src/act_info.c
@@ -1118,12 +1118,16 @@ void do_score (CHAR_DATA *ch, char *argument)
                 get_age(ch), (get_age(ch)-17)*4 );
         strcat( buf1, buf );
 
-        sprintf( buf, "Autoexit: %s  Autoloot: %s  Autocoin: %s  Autosac: %s  Autowield: %s\n\r\n\r",
-                IS_SET(ch->act, PLR_AUTOEXIT)   ? "{GYES{x" : "{RNO{x",
-                IS_SET(ch->act, PLR_AUTOLOOT)   ? "{GYES{x" : "{RNO{x",
-                IS_SET(ch->act, PLR_AUTOCOIN)   ? "{GYES{x" : "{RNO{x",
-                IS_SET(ch->act, PLR_AUTOSAC)    ? "{GYES{x" : "{RNO{x",
-                IS_SET(ch->act, PLR_AUTOWIELD)  ? "{GYES{x" : "{RNO{x" );
+        sprintf( buf, "Autoexit: %s  Autoloot: %s  Autocoin: %s\n\r",
+                IS_SET(ch->act, PLR_AUTOEXIT)   ? "{GYES {x" : "{RNO  {x",
+                IS_SET(ch->act, PLR_AUTOLOOT)   ? "{GYES {x" : "{RNO  {x",
+                IS_SET(ch->act, PLR_AUTOCOIN)   ? "{GYES{x" : "{RNO {x");
+        strcat( buf1, buf );
+
+        sprintf( buf, "Autosac: %s  Autowield: %s  Autolevel: %s\n\r\n\r",
+                IS_SET(ch->act, PLR_AUTOSAC)    ? "{G YES{x" : "{R NO {x",
+                IS_SET(ch->act, PLR_AUTOWIELD)  ? "{GYES{x" : "{RNO {x",
+                IS_SET(ch->act, PLR_AUTOLEVEL)  ? "{GYES{x" : "{RNO {x" );
         strcat( buf1, buf );
 
         print_player_status (ch, buf);
@@ -3582,6 +3586,11 @@ void do_config( CHAR_DATA *ch, char *argument )
                              : "[-autosac  ] You don't automatically sacrifice corpses.\n\r"
                              , ch );
 
+                send_to_char(  IS_SET( ch->act, PLR_AUTOLEVEL  )
+                             ? "[+AUTOLEVEL] You automatically level if you have enough experience.\n\r"
+                             : "[-autolevel] You don't automatically level if you have enough experience.\n\r"
+                             , ch );
+
                 send_to_char(  IS_SET( ch->act, PLR_BLANK     )
                              ? "[+BLANK    ] You have a blank line before your prompt.\n\r"
                              : "[-blank    ] You have no blank line before your prompt.\n\r"
@@ -3665,6 +3674,7 @@ void do_config( CHAR_DATA *ch, char *argument )
                 else if ( !str_cmp( arg+1, "autoloot" ) ) bit = PLR_AUTOLOOT;
                 else if ( !str_cmp( arg+1, "autocoin" ) ) bit = PLR_AUTOCOIN;
                 else if ( !str_cmp( arg+1, "autosac"  ) ) bit = PLR_AUTOSAC;
+                else if ( !str_cmp( arg+1, "autolevel") ) bit = PLR_AUTOLEVEL;
                 else if ( !str_cmp( arg+1, "blank"    ) ) bit = PLR_BLANK;
                 else if ( !str_cmp( arg+1, "brief"    ) ) bit = PLR_BRIEF;
                 else if ( !str_cmp( arg+1, "combine"  ) ) bit = PLR_COMBINE;
@@ -3799,6 +3809,17 @@ void do_autocoin (CHAR_DATA *ch, char *argument)
         (IS_SET(ch->act, PLR_AUTOCOIN))
                 ? sprintf(buf, "-autocoin")
                         : sprintf(buf, "+autocoin");
+        do_config(ch, buf);
+}
+
+
+void do_autolevel (CHAR_DATA *ch, char *argument)
+{
+        char buf [16];
+
+        (IS_SET(ch->act, PLR_AUTOLEVEL))
+                ? sprintf(buf, "-autolevel")
+                        : sprintf(buf, "+autolevel");
         do_config(ch, buf);
 }
 

--- a/server/src/comm.c
+++ b/server/src/comm.c
@@ -2116,7 +2116,8 @@ void nanny (DESCRIPTOR_DATA *d, char *argument)
 
                 send_to_char("\n\r\n\r{WCharacter generation complete.{x\n\r"
                              "You are now ready to enter the Dragons Domain and begin your training!\n\r", ch);
-                ch->pcdata->pagelen = 25;
+                SET_BIT(ch->act, PLR_AUTOLEVEL);
+                ch->pcdata->pagelen = 100;
                 d->connected = CON_READ_MOTD;
                 break;
 

--- a/server/src/interp.c
+++ b/server/src/interp.c
@@ -126,6 +126,7 @@ const struct cmd_type cmd_table [] =
         { "autoexit",       do_autoexit,    POS_DEAD,        0,  LOG_NORMAL },
         { "autowield",      do_autowield,   POS_DEAD,        0,  LOG_NORMAL },
         { "autoloot",       do_autoloot,    POS_DEAD,        0,  LOG_NORMAL },
+        { "autolevel",      do_autolevel,   POS_DEAD,        0,  LOG_NORMAL },
         { "autosac",        do_autosac,     POS_DEAD,        0,  LOG_NORMAL },
         { "blank",          do_blank,       POS_DEAD,        0,  LOG_NORMAL },
         { "brief",          do_brief,       POS_DEAD,        0,  LOG_NORMAL },

--- a/server/src/merc.h
+++ b/server/src/merc.h
@@ -2058,7 +2058,7 @@ extern DIR_DATA directions [ MAX_DIR ];
 #define PLR_DENY                        BIT_20
 #define PLR_FREEZE                      BIT_21
 #define PLR_GUIDE                       BIT_22  /* was PLR_THIEF */
-/* #define PLR_KILLER                   BIT_23 */
+#define PLR_AUTOLEVEL                   BIT_23  /* Owl 16/3/22 */
 #define PLR_ANSI                        BIT_24
 #define PLR_VT100                       BIT_25
 #define PLR_AFK                         BIT_26
@@ -3327,6 +3327,7 @@ DECLARE_DO_FUN( do_autocoin                     );      /* autoloot coin from co
 DECLARE_DO_FUN( do_autoexit                     );
 DECLARE_DO_FUN( do_autowield                    );
 DECLARE_DO_FUN( do_autoloot                     );
+DECLARE_DO_FUN( do_autolevel                    );      /* automatically level when you have enough experience; Owl */
 DECLARE_DO_FUN( do_autosac                      );
 DECLARE_DO_FUN( do_backstab                     );
 DECLARE_DO_FUN( do_balance                      );      /* for bank - Brutus */

--- a/server/src/update.c
+++ b/server/src/update.c
@@ -350,6 +350,13 @@ void gain_exp( CHAR_DATA *ch, int gain )
                         ch->exp = level_table[ch->level].exp_total - 1;
                         return;
                 }
+                /* Check to see if level lock is on */
+                if (!( IS_SET ( ch->act, PLR_AUTOLEVEL ) ) )
+                {
+                        ch->exp = level_table[ch->level].exp_total - 1;
+                        send_to_char("You cannot level while {WAUTOLEVEL{x is set to {RNO{x.\n\r", ch);
+                        return;
+                }
 
                 if(ch->pcdata->fame < 0)
                 {


### PR DESCRIPTION
- Added "autolevel" toggle so that you can level lock characters.  
- New characters will start with it toggled "on" so they can level normally, but it will default to off for current characters. 
- I've put a message in the MOTD letting people know to toggle it on when they log in with old characters, and will be announcing it on the Discord etc.  You'll also get a message telling you it's set to NO and will drain off xp to next level -1 if you gain xp, so hopefully no confusion.