### PR TITLE
v1 of Grouping XP bonuses for Support actions

### DIFF
--- a/server/area/hitower.are
+++ b/server/area/hitower.are
@@ -339,6 +339,8 @@ easily and effectively.
 & 85 'illusion magiks'
 & 85 'disease magiks'
 & 85 'protective magiks'
+& 85 'summoning magiks'
+& 85 'mana control disciplines'
 #1329
 wizard~
 an aged wizard~

--- a/server/src/fight.c
+++ b/server/src/fight.c
@@ -695,6 +695,38 @@ bool one_hit (CHAR_DATA *ch, CHAR_DATA *victim, int dt)
 
 
 /*
+ * 22.3.22 - Shade group support bonus
+ */
+
+void check_group_bonus(CHAR_DATA *ch) 
+{
+        CHAR_DATA *vch;
+        CHAR_DATA *vch_next;
+
+        for (vch = ch->in_room->people; vch; vch = vch_next)
+        {
+                vch_next = vch->next_in_room;
+
+                if (ch == vch)
+                        continue;
+
+                if (vch->deleted)
+                        continue;
+
+                if (IS_NPC(vch))
+                        continue;
+
+                if (is_same_group(vch, ch)) 
+                {
+                        ch->pcdata->group_support_bonus += 1;
+                        break;
+                }
+                
+        }
+
+}
+
+/*
  * Inflict damage from a hit.
  */
 void death_penalty (CHAR_DATA *ch, CHAR_DATA *victim)
@@ -2305,6 +2337,45 @@ void group_gain (CHAR_DATA *ch, CHAR_DATA *victim)
                         sprintf(buf, "You get a grouping bonus of %d experience points.\n\r", grxp);
                         send_to_char(buf, gch);
                         gain_exp(gch, grxp);
+
+                        /*
+                         * Shade 22.3.22
+                         *
+                         * Grouping support bonus
+                         * 
+                         * The aim is to give a little boost to casters doing defensive and otherwise useful spells but not damage which gives XP.  Help lower level
+                         * casters who won't do a lot of damage relative to someone tanking for them.
+                         * 
+                         * group_support_bonus is incremented in most defensive/support spells and some non damaging skills / spells eg Trap, Web, Faerie Fire
+                         * 
+                         */
+
+                        if (gch->pcdata->group_support_bonus > 0)
+                        {
+                                /*
+                                 * Starting point - let's try 33% xp bonus per helpful action
+                                 */
+
+                                grxp = (xp / 3) * gch->pcdata->group_support_bonus;
+
+                                /*
+                                 * So players will figure out how to abuse this I'm sure so let's cap it 
+                                 */
+
+                                if (grxp > (2 * xp)) 
+                                {
+                                        sprintf(buf, "Capping max group bonus for %s", gch->name);
+                                        log_string(buf);
+                                        grxp = 2 * xp;
+                                }
+
+                                sprintf(buf, "For supporting your group, you gain %d bonus experience points.\n\r", grxp);
+                                send_to_char(buf, gch);
+                                gain_exp(gch, grxp);
+
+                                gch->pcdata->group_support_bonus = 0;       
+                        }
+
                 }
 
                 if (IS_SET(victim->act, ACT_LOSE_FAME))
@@ -2741,6 +2812,9 @@ void disarm (CHAR_DATA *ch, CHAR_DATA *victim)
                 obj_to_char(obj, victim);
         else
                 obj_to_room(obj, victim->in_room);
+
+        check_group_bonus(ch);
+
 }
 
 
@@ -3977,6 +4051,9 @@ void do_dirt_kick (CHAR_DATA *ch, char *argument)
                 af.bitvector    = AFF_BLIND;
 
                 affect_to_char(victim,&af);
+
+                check_group_bonus(ch);
+
         }
         else
                 damage(ch, victim, 0, gsn_dirt, FALSE);
@@ -4189,6 +4266,8 @@ void do_trap (CHAR_DATA *ch, char *argument)
 
                 if (!IS_NPC(ch) && ch->pcdata->tailing)
                         ch->pcdata->tailing = str_dup( "" );
+
+                check_group_bonus(ch);
         }
         else
         {
@@ -4294,6 +4373,9 @@ void do_transfix (CHAR_DATA *ch, char *argument)
 
                 affect_to_char(victim, &af);
                 WAIT_STATE (victim,    2 * PULSE_VIOLENCE);
+
+                check_group_bonus(ch);
+
 
                 if (!IS_NPC(ch) && ch->pcdata->tailing)
                         ch->pcdata->tailing = str_dup( "" );
@@ -4827,6 +4909,8 @@ void do_stun (CHAR_DATA *ch, char *argument)
                 affect_to_char(victim,&af);
 
                 do_sleep(victim,"");
+
+                check_group_bonus(ch);
 
                 WAIT_STATE (victim, 2 * PULSE_VIOLENCE);
         }

--- a/server/src/merc.h
+++ b/server/src/merc.h
@@ -2341,6 +2341,7 @@ struct  pc_data
         int                             allow_look;
         time_t                          review_stamp;
         int                             pattern;
+        int                             group_support_bonus;
 };
 
 
@@ -4035,6 +4036,7 @@ void    chat_killer                     args( ( CHAR_DATA *ch, CHAR_DATA *victim
 void    reset_char_stats                      ( CHAR_DATA *ch);
 bool    aggro_damage                          ( CHAR_DATA *ch, CHAR_DATA *victim, int damage );
 void    check_autoloot                        ( CHAR_DATA *ch, CHAR_DATA *victim );
+void    check_group_bonus                     (CHAR_DATA *ch) ;
 
 /* handler.c */
 int     get_dir                         args( ( char *txt  ) );

--- a/server/src/save.c
+++ b/server/src/save.c
@@ -497,6 +497,7 @@ bool load_char_obj (DESCRIPTOR_DATA *d, char *name)
         ch->pcdata->stat_train = APPLY_STR;
         ch->pcdata->pagelen = 25;
         ch->pcdata->switched = FALSE;
+        ch->pcdata->group_support_bonus = 0;
 
         for (next = 0; next < MAX_WEAR; next++)
                 ch->pcdata->morph_list[next] = NULL;

--- a/server/src/sft.c
+++ b/server/src/sft.c
@@ -549,6 +549,8 @@ void do_web (CHAR_DATA *ch, char *argument)
 
                 WAIT_STATE(victim, PULSE_VIOLENCE);
 
+                check_group_bonus(ch);
+
         }
         else 
         {

--- a/server/src/skill.c
+++ b/server/src/skill.c
@@ -204,6 +204,9 @@ void do_gouge (CHAR_DATA *ch, char *argument)
                 af.modifier  = -4;
                 af.bitvector = AFF_BLIND;
                 affect_to_char(victim, &af);
+
+                check_group_bonus(ch);
+
         }
         else
                 damage(ch, victim, 0, gsn_gouge, FALSE);
@@ -299,8 +302,9 @@ void do_choke (CHAR_DATA *ch, char *argument)
                 affect_to_char(victim, &af);
                 
                 do_sleep(victim, "");
+                check_group_bonus(ch);
                 
-                WAIT_STATE(victim, 3 * PULSE_VIOLENCE);
+                WAIT_STATE(victim, 2 * PULSE_VIOLENCE);
         }
         else
                 damage(ch, victim, 0, gsn_choke, FALSE);
@@ -1647,6 +1651,9 @@ void do_break_wrist (CHAR_DATA *ch, char *argument)
                 obj_from_char(obj);
                 obj_to_room(obj, victim->in_room);
                 damage(ch, victim, number_range (20, ch->level), gsn_break_wrist, FALSE);
+
+                check_group_bonus(ch);
+
         }
         else
                 damage(ch , victim, 0 , gsn_break_wrist, FALSE);


### PR DESCRIPTION
v1 of Grouping Bonuses for Support Actions

- 33% bonus XP per helpful action - capped at max 6
- Added to support skills such as trap, dirt kick, disarm
- Added to support spells such as shield, fly
- Added to curative magiks

Fixed up say_spell so casters will utter again