### PR TITLE
fix problems with AFF_FLYING not being applied and stripped properly

### DIFF
--- a/server/area/helpfile.are
+++ b/server/area/helpfile.are
@@ -672,7 +672,8 @@ Syntax: cast 'astral sidestep'
 
 Slip from the material world into the astral plane.  While in this
 parallel dimension, you won't be able to interact with the creatures and
-objects in the real world in any tangible way.
+objects in the real world in any tangible way. You will not experience
+hunger and thirst while in the astral plane.
 
 Type VISIBLE to return to the material plane.
 ~
@@ -5088,7 +5089,8 @@ One of the most difficult forms to master, the humble fly may seem puny
 but its uses are many.  Being so small, it poses no threat to any creature
 in the Domain.  Of course its lack of size means that it cannot carry
 anything.  Additional to that, is its ability to get through the locks of
-Doors.  Of course this only applies to doors who have locks!
+Doors.  Of course this only applies to doors who have locks!  You will
+not experience hunger or thirst while in fly form.
 ~
 
 0 'PHOENIX FORM'~
@@ -6113,7 +6115,7 @@ delete status.
 WARNING!  This command is irreversible!  It is not the Imms' responsibility if
 you were drunk/your little brother did it/your cat stood on your keyboard/you
 wanted to see how it worked/whatever!  Only delete if you are totally sure you
-will not want your character or any of its equipment of inventory again.
+will not want your character or any of its equipment or inventory again.
 ~
 
 0 NEWSOCIALS~

--- a/server/area/vampcat.are
+++ b/server/area/vampcat.are
@@ -4607,8 +4607,8 @@ is emanating from an oven that someone has foolishly left going. You no longer
 shiver and thank your deity for small mercies.
 
 Westwards lies the darkened corridor and a silvery door is at the back of the
-kitchen to the north.~
-
+kitchen to the north.
+~
 0 8 0
 D0
 ~

--- a/server/area/vampcat3.are
+++ b/server/area/vampcat3.are
@@ -466,7 +466,7 @@ and defeated gaze you know it has wandered long in these evil woods. It regards
 you mournfully and with desperate hunger in its eyes. Now what do horses like
 to eat...?
 ~
-2|64|131072 0 0 S
+2|64|1024|131072 0 0 S
 45 0 0 0d0+0 0d0+0
 36 0
 8 8 1

--- a/server/src/act_info.c
+++ b/server/src/act_info.c
@@ -1461,7 +1461,7 @@ void do_affects( CHAR_DATA *ch, char *argument )
                 strcat( buf1, buf );
 
                 if (ch->level >= 20)
-                        strcat (buf1, "               until you change form");
+                        strcat (buf1, "                      until you change form");
 
                 strcat( buf1, "\n\r" );
         }

--- a/server/src/act_move.c
+++ b/server/src/act_move.c
@@ -1738,13 +1738,21 @@ void do_visible (CHAR_DATA *ch, char *argument)
         affect_strip (ch, gsn_astral_sidestep);
         affect_strip (ch, gsn_invis);
         affect_strip (ch, gsn_mass_invis);
-        affect_strip (ch, gsn_hide);
         affect_strip (ch, gsn_chameleon_power);
         affect_strip (ch, gsn_sneak);
         affect_strip (ch, gsn_shadow_form);
-        REMOVE_BIT (ch->affected_by, AFF_HIDE);
         REMOVE_BIT (ch->affected_by, AFF_INVISIBLE);
         REMOVE_BIT (ch->affected_by, AFF_SNEAK);
+
+        /* Owl 26/3/22, to produce expected behaviour */
+        if (ch->form != FORM_CHAMELEON)
+        {
+                affect_strip (ch, gsn_hide);
+                REMOVE_BIT (ch->affected_by, AFF_HIDE);
+        }
+        else {
+                send_to_char("You will continue to hide as as long as you are in chameleon form.\n\r",ch);
+        }
 
         if (is_affected(ch,gsn_mist_walk))
         {

--- a/server/src/fight.c
+++ b/server/src/fight.c
@@ -953,6 +953,8 @@ void damage (CHAR_DATA *ch, CHAR_DATA *victim, int dam, int dt, bool poison)
                         if (IS_NPC(ch)
                             && !IS_AFFECTED(victim, AFF_FLYING)
                             && !is_affected(victim, gsn_haste)
+                            && !is_affected(victim, gsn_fly)
+                            && !is_affected(victim, gsn_levitation)
                             && number_percent() < (leveldiff < -5
                                                    ? ch->level / 2
                                                    : UMAX(20, leveldiff))

--- a/server/src/sft.c
+++ b/server/src/sft.c
@@ -140,12 +140,14 @@ void do_spy (CHAR_DATA *ch, char *argument)
 void do_morph_hawk (CHAR_DATA *ch, bool to_form) 
 {
         AFFECT_DATA af;
-        
+
         if (to_form)
         {
                 if (ch->pcdata->learned[gsn_form_hawk] > 40 || ch->pcdata->learned[gsn_fly])
                 {
                         affect_strip(ch, gsn_fly);
+                        affect_strip(ch, gsn_levitation);
+                        REMOVE_BIT(ch->affected_by, AFF_FLYING);
                         send_to_char("Your new form enables you to fly.\n\r", ch);
 
                         af.type      = gsn_fly;
@@ -159,6 +161,7 @@ void do_morph_hawk (CHAR_DATA *ch, bool to_form)
         else
         {      
                 affect_strip(ch, gsn_fly);
+                affect_strip(ch, gsn_levitation);
                 REMOVE_BIT(ch->affected_by, AFF_FLYING);
         }
 }
@@ -1358,6 +1361,8 @@ void do_morph_dragon (CHAR_DATA *ch, bool to_form)
                     || ch->pcdata->learned[gsn_fly])
                 {
                         affect_strip(ch, gsn_fly);
+                        affect_strip(ch, gsn_levitation);
+                        REMOVE_BIT(ch->affected_by, AFF_FLYING);
                         send_to_char("Your new form enables you to fly.\n\r", ch);
                         
                         af.type      = gsn_fly;
@@ -1470,6 +1475,7 @@ void do_morph_dragon (CHAR_DATA *ch, bool to_form)
         else 
         {
                 affect_strip(ch, gsn_fly);
+                affect_strip(ch, gsn_levitation);
                 affect_strip(ch, gsn_dragon_aura);
                 REMOVE_BIT(ch->affected_by, AFF_FLYING);
                 
@@ -1501,6 +1507,7 @@ void do_morph_phoenix (CHAR_DATA *ch, bool to_form)
                     || (ch->pcdata->learned[gsn_fly])) 
                 {
                         affect_strip(ch, gsn_fly);
+                        affect_strip(ch, gsn_levitation);
                         send_to_char("Your new form enables you to fly.\n\r", ch);
  
                         af.type      = gsn_fly;
@@ -1547,6 +1554,7 @@ void do_morph_phoenix (CHAR_DATA *ch, bool to_form)
         else 
         {
                 affect_strip(ch, gsn_fly);
+                affect_strip(ch, gsn_levitation);
                 REMOVE_BIT(ch->affected_by, AFF_FLYING);
                 affect_strip(ch,gsn_fireshield);
                 REMOVE_BIT(ch->affected_by, AFF_FLAMING);
@@ -1583,6 +1591,9 @@ void do_morph_fly (CHAR_DATA *ch, bool to_form)
                 if ((ch->pcdata->learned[gsn_form_fly] > 10) || (ch->pcdata->learned[gsn_fly])) 
                 {
                         affect_strip(ch, gsn_fly);
+                        affect_strip(ch, gsn_levitation);
+                        REMOVE_BIT(ch->affected_by, AFF_FLYING);
+
                         send_to_char("Your new form enables you to fly.\n\r", ch);
                         
                         af.type      = gsn_form_fly;
@@ -1614,6 +1625,9 @@ void do_morph_demon (CHAR_DATA *ch, bool to_form)
                 if (ch->pcdata->learned[gsn_form_demon] > 10 || ch->pcdata->learned[gsn_fly])
                 {
                         affect_strip(ch, gsn_fly);
+                        affect_strip(ch, gsn_levitation);
+                        REMOVE_BIT(ch->affected_by, AFF_FLYING);
+
                         send_to_char("Your new form enables you to fly.\n\r", ch);
                         
                         af.type      = gsn_fly;
@@ -1627,6 +1641,7 @@ void do_morph_demon (CHAR_DATA *ch, bool to_form)
         else
         {
                 affect_strip(ch, gsn_fly);
+                affect_strip(ch, gsn_levitation);
                 REMOVE_BIT(ch->affected_by, AFF_FLYING);
         }
 }
@@ -1644,6 +1659,9 @@ void do_morph_griffin (CHAR_DATA *ch, bool to_form)
                 if (ch->pcdata->learned[gsn_form_fly] > 10 || ch->pcdata->learned[gsn_fly])
                 {
                         affect_strip(ch, gsn_fly);
+                        affect_strip(ch, gsn_levitation);
+                        REMOVE_BIT(ch->affected_by, AFF_FLYING);
+
                         send_to_char("Your new form enables you to fly.\n\r", ch);
                         
                         af.type      = gsn_fly;
@@ -1714,6 +1732,7 @@ void do_morph_griffin (CHAR_DATA *ch, bool to_form)
         else
         {
                 affect_strip(ch, gsn_fly);   
+                affect_strip(ch, gsn_levitation);
                 REMOVE_BIT(ch->affected_by, AFF_FLYING);
                  
                 claws = get_obj_wear(ch, "sftclaws");
@@ -1771,15 +1790,6 @@ void do_morph (CHAR_DATA *ch, char *argument)
                 send_to_char("Which form was that?\n\r", ch);
                 return;
         }
-
-        /*
-        if (ch->mount)
-        {
-                send_to_char ("You may not morph while mounted.\n\r", ch);
-                return;   
-        }
-            Makes mount useless for shifters.  Disabled.  -- Owl 8/3/22
-        */
         
         if( ch->sub_class == SUB_CLASS_VAMPIRE && form != FORM_NORMAL ) 
         {
@@ -1870,7 +1880,7 @@ void do_morph (CHAR_DATA *ch, char *argument)
         form_equipment_update(ch);
         
         sprintf(buf, "\n\rYou morph from %s", extra_form_name(old_form));       
-        sprintf(buf1, " to %s forms.\n\r", extra_form_name(form));
+        sprintf(buf1, " to %s form.\n\r", extra_form_name(form));
         strcat(buf, buf1);
         
         send_to_char(buf, ch);

--- a/server/src/skill.c
+++ b/server/src/skill.c
@@ -36,9 +36,10 @@ void do_fly (CHAR_DATA *ch, char* argument )
 
         if (IS_AFFECTED(ch, AFF_FLYING))
         {
-                send_to_char ("You stop flying.\n\r", ch);
+                send_to_char ("You slowly float to the ground.\n\r", ch);
                 act ("$c stops flying.", ch, NULL, NULL, TO_ROOM);
                 affect_strip (ch, gsn_fly);
+                REMOVE_BIT(ch->affected_by, AFF_FLYING);
                 return;
         }
         

--- a/server/src/update.c
+++ b/server/src/update.c
@@ -2221,7 +2221,7 @@ void form_equipment_update (CHAR_DATA *ch)
                 {
                         if (IS_SET(obj->extra_flags, ITEM_BODY_PART))
                         {
-                                unequip_char(ch, obj);
+                               unequip_char(ch, obj);
                                 extract_obj(obj);
                         }
 

--- a/server/src/update.c
+++ b/server/src/update.c
@@ -944,7 +944,8 @@ void gain_condition( CHAR_DATA *ch, int iCond, int value )
             || value == -10
             || ch->level >= LEVEL_HERO
             || ch->level < 2
-            || ch->sub_class == SUB_CLASS_VAMPIRE)
+            || ch->sub_class == SUB_CLASS_VAMPIRE
+            || IS_AFFECTED(ch, AFF_NON_CORPOREAL) )
                 return;
 
         condition = ch->pcdata->condition[iCond];


### PR DESCRIPTION
- Was trying to fix other problems BUT ANYWAY.  Shouldn't be fly weirdness with shifters now (where you can cast it multiple times on a person in some circumstances, or it doesn't protect against tripping etc) and fixes some corners cases with 'levitation' interactions (you could get levitation from a potion and then shift to a form that gave you fly and it wouldn't behave sensibly).  Stripping fly now also strips levitation.

- Made HIDE behave a bit better for chameleon form (it shouldn't be able to be dispelled/removed in the normal way and a check or two had been missed)

- Couple of small area tweaks, made horses cursed and fixed a missing newline

- Disabled hunger/thirst update checking for fly form/astral sidestep/mist walk.  Updated helps for these.