### PR TITLE
Added race checks to mobprogs, some minor tweaks to mset and mstat

### DIFF
--- a/server/src/act_wiz.c
+++ b/server/src/act_wiz.c
@@ -1099,10 +1099,11 @@ void do_mstat( CHAR_DATA *ch, char *argument )
                 }
         }
 
-        sprintf( buf, "Vnum: %d.  Sex: %s.  Room: %d.\n\r",
+        sprintf( buf, "Vnum: %d.  Sex: %s.  Race: %d.  Room: %d.\n\r",
                 IS_NPC( victim ) ? victim->pIndexData->vnum : 0,
                 victim->sex == SEX_MALE    ? "male"   :
                 victim->sex == SEX_FEMALE  ? "female" : "neutral",
+                victim->race,
                 !victim->in_room           ?        0 : victim->in_room->vnum );
         strcat( buf1, buf );
 
@@ -1146,7 +1147,7 @@ void do_mstat( CHAR_DATA *ch, char *argument )
         if ( !IS_NPC( victim ) )
         {
                 sprintf( buf,
-                        "Thirst: %d.  Full: %d.  Drunk: %d.  Position: %s [%d.  Wimpy: %d.  Page Lines: %d.\n\r",
+                        "Thirst: %d.  Full: %d.  Drunk: %d.\n\r  Position: %s [%d].  Wimpy: %d.  Page Lines: %d.\n\r",
                         victim->pcdata->condition[COND_THIRST],
                         victim->pcdata->condition[COND_FULL  ],
                         victim->pcdata->condition[COND_DRUNK ],
@@ -3473,7 +3474,7 @@ void do_mset( CHAR_DATA *ch, char *argument )
                         return;
                 }
 
-                ch->race = value;
+                victim->race = value;
                 return;
         }
 

--- a/server/src/mob_prog.c
+++ b/server/src/mob_prog.c
@@ -671,6 +671,46 @@ bool mprog_do_ifchck( char *ifchck, CHAR_DATA *mob, CHAR_DATA *actor,
           return -1;
         }
     }
+  
+  /* Add testing based on race, Owl 5/4/22 */
+  
+  if ( !str_cmp( buf, "race" ) )
+    {
+      switch ( arg[1] )  /* arg should be "$*" so just get the letter */
+        {
+        case 'i': lhsvl = mob->race;
+                  rhsvl = atoi( val );
+                  return mprog_veval( lhsvl, opr, rhsvl );
+        case 'n': if ( actor )
+                  {
+                    lhsvl = actor->race;
+                    rhsvl = atoi( val );
+                    return mprog_veval( lhsvl, opr, rhsvl );
+                  }
+                  else 
+                    return -1;
+        case 't': if ( vict )
+                  {
+                    lhsvl = vict->race;
+                    rhsvl = atoi( val );
+                    return mprog_veval( lhsvl, opr, rhsvl );
+                  }
+                  else
+                    return -1;
+        case 'r': if ( rndm )
+                  {
+                    lhsvl = rndm->race;
+                    rhsvl = atoi( val );
+                    return mprog_veval( lhsvl, opr, rhsvl );
+                  }
+                  else
+                    return -1;
+        default:
+          bug ( "Mob: %d bad argument to 'race'", mob->pIndexData->vnum ); 
+          return -1;
+        }
+    }
+
 
   if ( !str_cmp( buf, "class" ) )
     {


### PR DESCRIPTION
- Made it so you can check race with MOBProgs ( if race ($n) == 1 to test for Human, for example)
- Made it so you can mstat and mset victim->race
- Tested both these things, though msetting race on PCs might be a bad idea if done for reasons other than testing things (i.e. don't permanently change players' races on prod and expect not to encounter problems downstream)