### PR TITLE
item fix up

### DIFF
--- a/server/src/handler.c
+++ b/server/src/handler.c
@@ -1104,8 +1104,12 @@ void form_equip_char (CHAR_DATA *ch, OBJ_DATA *obj, int iWear)
         OBJ_DATA *removed = NULL;
 
         /* force removal of old weapon */
-        if ((removed = get_eq_char(ch, iWear)))
+        if ((removed = get_eq_char(ch, iWear))) 
+        {
+                /* Shade Apr 2022 - don't forget to remember the weapon if applicable */        
                 unequip_char(ch, removed);
+                ch->pcdata->morph_list[iWear] = removed;
+        }
 
         /* do the equipping */
         equip_char(ch, obj, iWear);

--- a/server/src/sft.c
+++ b/server/src/sft.c
@@ -1018,7 +1018,7 @@ void do_forage(CHAR_DATA *ch,  char *argument)
 void do_morph_bear (CHAR_DATA *ch, bool to_form) 
 {
         OBJ_DATA *claws;
-        
+
         if (to_form) 
         {
                 claws = create_object(get_obj_index(OBJ_BEAR_CLAWS), ch->level);
@@ -1030,8 +1030,15 @@ void do_morph_bear (CHAR_DATA *ch, bool to_form)
                         form_equip_char(ch, claws, WEAR_WIELD);
                 }
         }
-        else 
+        else        
         {
+
+                /*
+                 * form_equipment_update has already been called before coming here; claws are probably removed
+                 *
+                 * if things aren't working, don't try and fix here
+                 */
+
                 claws = get_obj_wear(ch, "sftclaws");
                 if (claws) 
                 {

--- a/server/src/update.c
+++ b/server/src/update.c
@@ -2212,6 +2212,7 @@ void add_morph_list(CHAR_DATA *ch, int iWear)
 
         unequip_char(ch, theObj);
         ch->pcdata->morph_list[iWear] = theObj;
+        
 }
 
 
@@ -2242,6 +2243,10 @@ void form_equipment_update (CHAR_DATA *ch)
 
                 obj = get_eq_char(ch, iter);
 
+                /*
+                 * no object currently worn - reapply what was there
+                 */
+
                 if (!obj)
                 {
                         if (form_wear_table[ch->form].can_wear[jter])
@@ -2250,14 +2255,20 @@ void form_equipment_update (CHAR_DATA *ch)
 
                 else
                 {
+                        /*
+                         * there is an object there
+                         */
+
                         if (IS_SET(obj->extra_flags, ITEM_BODY_PART))
                         {
-                               unequip_char(ch, obj);
+                                unequip_char(ch, obj);
                                 extract_obj(obj);
+                                rem_morph_list(ch, iter); /* Shade added April 2022 */
                         }
 
                         else if (!form_wear_table[ch->form].can_wear[jter])
                                 add_morph_list(ch, iter);
+                                
                 }
         }
 }


### PR DESCRIPTION
Looks like saving equipment was added afterwards.

In do_morph_x, there is code where you're leaving the form and it removes the claws or whatever.  Pretty sure that code isn't called, form_equipment_update handled it earlier.  So adding a fix there wasn't helping.

Actual fix is just to remember the weapon when it's removed, then in form_equipment_update when the body part is destroyed just reapply what was there.

Have tested normal -> bear -> normal, normal -> scorpion -> normal, and combinations of.  Haven't tested higher forms as not to familiar with them, dual might give us issues if something dual wields.