### PR TITLE
AFF_NON_CORPOREAL grouping issues partial fix

### DIFF
--- a/server/src/act_comm.c
+++ b/server/src/act_comm.c
@@ -1570,6 +1570,12 @@ void do_group_order( CHAR_DATA *ch, char *argument)
                 return;
         }
 
+        if (IS_AFFECTED(victim, AFF_NON_CORPOREAL))
+        {
+                send_to_char("Groups may not be led by the non-corporeal.\n\r", ch);
+                return;
+        }
+
         if (!is_same_group(ch, victim))
         {
                 send_to_char("They're not in your group.\n\r", ch);

--- a/server/src/act_move.c
+++ b/server/src/act_move.c
@@ -1605,6 +1605,12 @@ void do_mist_walk(CHAR_DATA *ch, char *argument )
                 return;
         }
 
+        if (ch->pcdata->group_leader == ch)
+        {
+                send_to_char("You can't lead a group in a non-corporeal form.\n\r", ch);
+                return;
+        }
+
         if (is_affected(ch, gsn_mist_walk))
                 return;
 

--- a/server/src/magic.c
+++ b/server/src/magic.c
@@ -6672,6 +6672,12 @@ void spell_astral_sidestep( int sn, int level, CHAR_DATA *ch, void *vo )
         if ( IS_NPC(ch) )
                 return;
 
+        if (ch->pcdata->group_leader == ch)
+        {
+                send_to_char("You can't lead a group in a non-corporeal form.\n\r", ch);
+                return;
+        }
+
         if (is_entered_in_tournament(ch)
             && tournament_status == TOURNAMENT_STATUS_RUNNING
             && is_still_alive_in_tournament(ch))

--- a/server/src/sft.c
+++ b/server/src/sft.c
@@ -10,7 +10,7 @@
 #include "merc.h"
 
 
-void do_morph_chameleon (CHAR_DATA *ch, bool to_form) 
+void do_morph_chameleon (CHAR_DATA *ch, bool to_form)
 {
         AFFECT_DATA af;
 
@@ -38,17 +38,17 @@ void do_morph_chameleon (CHAR_DATA *ch, bool to_form)
                         affect_to_char(ch, &af);
                 }
         }
-        else 
-        {      
+        else
+        {
                 affect_strip(ch, gsn_hide);
                 REMOVE_BIT(ch->affected_by, AFF_HIDE);
-                affect_strip(ch, gsn_sneak);    
+                affect_strip(ch, gsn_sneak);
                 REMOVE_BIT(ch->affected_by, AFF_SNEAK);
         }
 }
 
 
-void do_spy (CHAR_DATA *ch, char *argument) 
+void do_spy (CHAR_DATA *ch, char *argument)
 {
         CHAR_DATA       *wch;
         CHAR_DATA       *victim;
@@ -65,13 +65,13 @@ void do_spy (CHAR_DATA *ch, char *argument)
         if ( !IS_AWAKE( ch ) || !check_blind( ch ) )
                 return;
 
-        if ( !IS_NPC( ch ) && !CAN_DO( ch, gsn_spy ) ) 
+        if ( !IS_NPC( ch ) && !CAN_DO( ch, gsn_spy ) )
         {
                 send_to_char("You do not have that ability.\n\r", ch);
                 return;
         }
 
-        if (ch->form != FORM_HAWK) 
+        if (ch->form != FORM_HAWK)
         {
                 send_to_char("You must be in hawk form to surveil someone.\n\r", ch);
                 return;
@@ -82,12 +82,12 @@ void do_spy (CHAR_DATA *ch, char *argument)
                 send_to_char( "Surveil whom?\n\r", ch );
                 return;
         }
-        
+
         if ( !( victim = get_char_world( ch, arg ) ) || !victim->desc )
         {
                 send_to_char( "They are not currently in the domain.\n\r", ch );
                 return;
-        } 
+        }
 
         if ( victim == ch )
         {
@@ -113,8 +113,8 @@ void do_spy (CHAR_DATA *ch, char *argument)
                 return;
         }
 
-        /* 
-           Do the spying. basically check victim is in same area and force look output 
+        /*
+           Do the spying. basically check victim is in same area and force look output
            You can also surveil mobs.
         */
         location = find_location( ch, arg );
@@ -146,8 +146,8 @@ void do_soar(CHAR_DATA* ch, char* argument)
 
         if( IS_NPC( ch ) )
                 return;
-        
-        if( ch->class != CLASS_SHAPE_SHIFTER 
+
+        if( ch->class != CLASS_SHAPE_SHIFTER
         &&  !IS_IMMORTAL( ch ) )
         {
                 send_to_char("You don't know how to do that.\n\r", ch);
@@ -190,16 +190,16 @@ void do_soar(CHAR_DATA* ch, char* argument)
         if (!str_cmp(arg, "mem"))
         {
                 if ( IS_SET( ch->in_room->room_flags, ROOM_INDOORS )
-                ||   IS_SET( ch->in_room->room_flags, ROOM_PRIVATE ) 
-                ||   IS_SET( ch->in_room->room_flags, ROOM_SOLITARY ) 
+                ||   IS_SET( ch->in_room->room_flags, ROOM_PRIVATE )
+                ||   IS_SET( ch->in_room->room_flags, ROOM_SOLITARY )
                 ||   IS_SET( ch->in_room->room_flags, ROOM_NO_MOUNT )
-                || ( ch->in_room->sector_type != SECT_FIELD 
-                &&   ch->in_room->sector_type != SECT_FOREST 
-                &&   ch->in_room->sector_type != SECT_HILLS 
-                &&   ch->in_room->sector_type != SECT_MOUNTAIN 
+                || ( ch->in_room->sector_type != SECT_FIELD
+                &&   ch->in_room->sector_type != SECT_FOREST
+                &&   ch->in_room->sector_type != SECT_HILLS
+                &&   ch->in_room->sector_type != SECT_MOUNTAIN
                 &&   ch->in_room->sector_type != SECT_DESERT
                 &&   ch->in_room->sector_type != SECT_WATER_SWIM
-                &&   ch->in_room->sector_type != SECT_WATER_NOSWIM ) ) 
+                &&   ch->in_room->sector_type != SECT_WATER_NOSWIM ) )
                 {
                         send_to_char("You can't land in this sort of terrain.\n\r", ch);
                         return;
@@ -230,27 +230,27 @@ void do_soar(CHAR_DATA* ch, char* argument)
 
         if (!str_cmp(arg, "return"))
         {
-                /* 
+                /*
                  * You CAN soar to and from a no_recall room if other criteria are met.  Feature not a bug.
                  */
 
                 if ( IS_SET( ch->in_room->room_flags, ROOM_INDOORS )
-                ||   IS_SET( ch->in_room->room_flags, ROOM_PRIVATE ) 
-                ||   IS_SET( ch->in_room->room_flags, ROOM_SOLITARY ) 
+                ||   IS_SET( ch->in_room->room_flags, ROOM_PRIVATE )
+                ||   IS_SET( ch->in_room->room_flags, ROOM_SOLITARY )
                 ||   IS_SET( ch->in_room->room_flags, ROOM_NO_MOUNT )
-                || ( ch->in_room->sector_type != SECT_FIELD 
-                &&   ch->in_room->sector_type != SECT_FOREST 
-                &&   ch->in_room->sector_type != SECT_HILLS 
-                &&   ch->in_room->sector_type != SECT_MOUNTAIN 
+                || ( ch->in_room->sector_type != SECT_FIELD
+                &&   ch->in_room->sector_type != SECT_FOREST
+                &&   ch->in_room->sector_type != SECT_HILLS
+                &&   ch->in_room->sector_type != SECT_MOUNTAIN
                 &&   ch->in_room->sector_type != SECT_DESERT
                 &&   ch->in_room->sector_type != SECT_WATER_SWIM
-                &&   ch->in_room->sector_type != SECT_WATER_NOSWIM ) ) 
+                &&   ch->in_room->sector_type != SECT_WATER_NOSWIM ) )
 
                 {
                         send_to_char("You can't take off from this terrain.\n\r", ch);
                         return;
-                } 
-                else 
+                }
+                else
                 {
                         if (ch->pcdata->soar)
                         {
@@ -284,16 +284,16 @@ void do_soar(CHAR_DATA* ch, char* argument)
         }
 
         if ( IS_SET( ch->in_room->room_flags, ROOM_INDOORS )
-        ||   IS_SET( ch->in_room->room_flags, ROOM_PRIVATE ) 
-        ||   IS_SET( ch->in_room->room_flags, ROOM_SOLITARY ) 
+        ||   IS_SET( ch->in_room->room_flags, ROOM_PRIVATE )
+        ||   IS_SET( ch->in_room->room_flags, ROOM_SOLITARY )
         ||   IS_SET( ch->in_room->room_flags, ROOM_NO_MOUNT )
-        || ( ch->in_room->sector_type != SECT_FIELD 
-        &&   ch->in_room->sector_type != SECT_FOREST 
-        &&   ch->in_room->sector_type != SECT_HILLS 
-        &&   ch->in_room->sector_type != SECT_MOUNTAIN 
+        || ( ch->in_room->sector_type != SECT_FIELD
+        &&   ch->in_room->sector_type != SECT_FOREST
+        &&   ch->in_room->sector_type != SECT_HILLS
+        &&   ch->in_room->sector_type != SECT_MOUNTAIN
         &&   ch->in_room->sector_type != SECT_DESERT
         &&   ch->in_room->sector_type != SECT_WATER_SWIM
-        &&   ch->in_room->sector_type != SECT_WATER_NOSWIM ) ) 
+        &&   ch->in_room->sector_type != SECT_WATER_NOSWIM ) )
 
         {
                 send_to_char("You can't take off from this terrain.\n\r", ch);
@@ -310,7 +310,7 @@ void do_soar(CHAR_DATA* ch, char* argument)
         if (get_room_index(ch->in_room->vnum) == location)
         {
                 send_to_char("You're there right now!\n\r",ch);
-                return;   
+                return;
         }
 
         if ( ch->mount )
@@ -338,8 +338,8 @@ void do_soar(CHAR_DATA* ch, char* argument)
                 act ("{yYou release $N from your talons and $E splashes down into the water.\n\r{x", ch, NULL, ch->mount, TO_CHAR);
                 act ("{y$N releases $n from $S talons and $e splashes down into the water.\n\r{x", ch->mount, NULL, ch, TO_NOTVICT);
         }
-        
-        if ( ch->mount 
+
+        if ( ch->mount
         &&   ch->in_room->sector_type != SECT_WATER_SWIM
         &&   ch->in_room->sector_type != SECT_WATER_NOSWIM )
         {
@@ -349,10 +349,10 @@ void do_soar(CHAR_DATA* ch, char* argument)
 
         if ( ch->in_room->sector_type == SECT_WATER_SWIM
         ||   ch->in_room->sector_type == SECT_WATER_NOSWIM )
-        { 
+        {
                 act ("{y$c swoops down from the sky and lands gracefully on the water.{x", ch, NULL, NULL, TO_ROOM);
         }
-        else 
+        else
         {
                 act ("{y$c swoops down from the sky and alights nearby.{x", ch, NULL, NULL, TO_ROOM);
         }
@@ -384,7 +384,7 @@ bool is_valid_soar (CHAR_DATA *ch, int soar_index )
         return 0;
 }
 
-void do_morph_hawk (CHAR_DATA *ch, bool to_form) 
+void do_morph_hawk (CHAR_DATA *ch, bool to_form)
 {
         AFFECT_DATA af;
 
@@ -406,7 +406,7 @@ void do_morph_hawk (CHAR_DATA *ch, bool to_form)
                 }
         }
         else
-        {      
+        {
                 affect_strip(ch, gsn_fly);
                 affect_strip(ch, gsn_levitation);
                 REMOVE_BIT(ch->affected_by, AFF_FLYING);
@@ -414,13 +414,13 @@ void do_morph_hawk (CHAR_DATA *ch, bool to_form)
 }
 
 
-void do_morph_cat (CHAR_DATA *ch, bool to_form) 
+void do_morph_cat (CHAR_DATA *ch, bool to_form)
 {
         AFFECT_DATA af;
-        
+
         if (to_form)
         {
-                if (ch->pcdata->learned[gsn_form_cat] > 30) 
+                if (ch->pcdata->learned[gsn_form_cat] > 30)
                 {
                         affect_strip(ch, gsn_infravision);
                         send_to_char("Your new form causes your eyes to glow red.\n\r", ch);
@@ -431,10 +431,10 @@ void do_morph_cat (CHAR_DATA *ch, bool to_form)
                         af.modifier  = 0;
                         af.bitvector = AFF_INFRARED;
                         affect_to_char(ch, &af);
-                        
+
                 }
-                
-                if (ch->pcdata->learned[gsn_form_cat] > 50) 
+
+                if (ch->pcdata->learned[gsn_form_cat] > 50)
                 {
                         affect_strip(ch, gsn_detect_hidden);
                         send_to_char("Your new form causes your awareness to improve.\n\r", ch);
@@ -447,7 +447,7 @@ void do_morph_cat (CHAR_DATA *ch, bool to_form)
                         affect_to_char(ch, &af);
                 }
 
-                if (ch->pcdata->learned[gsn_form_cat] > 60) 
+                if (ch->pcdata->learned[gsn_form_cat] > 60)
                 {
                         affect_strip(ch, gsn_detect_invis);
                         send_to_char("Your new form causes your senses to rocket.\n\r", ch);
@@ -469,7 +469,7 @@ void do_morph_cat (CHAR_DATA *ch, bool to_form)
 
         }
         else
-        {      
+        {
                 affect_strip(ch, gsn_infravision);
                 REMOVE_BIT(ch->affected_by, AFF_INFRARED);
                 affect_strip(ch, gsn_detect_hidden);
@@ -478,29 +478,29 @@ void do_morph_cat (CHAR_DATA *ch, bool to_form)
                 REMOVE_BIT(ch->affected_by, AFF_DETECT_INVIS);
                 affect_strip(ch, gsn_detect_sneak);
                 REMOVE_BIT(ch->affected_by, AFF_DETECT_SNEAK);
-                affect_strip(ch, gsn_heighten);   
+                affect_strip(ch, gsn_heighten);
         }
 }
 
 
-void do_coil (CHAR_DATA *ch, char *argument) 
+void do_coil (CHAR_DATA *ch, char *argument)
 {
         CHAR_DATA *victim;
         AFFECT_DATA af;
         char arg[MAX_INPUT_LENGTH];
 
-        if (!IS_NPC(ch) && !CAN_DO(ch, gsn_coil)) 
+        if (!IS_NPC(ch) && !CAN_DO(ch, gsn_coil))
         {
                 send_to_char("You tie yourself in knots foolishly trying to impersonate a snake.\n\r", ch);
                 return;
         }
-        
-        if (ch->form != FORM_SNAKE) 
+
+        if (ch->form != FORM_SNAKE)
         {
                 send_to_char("You are not in the correct form.\n\r", ch);
                 return;
         }
- 
+
         victim = ch->fighting;
         one_argument(argument, arg);
 
@@ -509,89 +509,89 @@ void do_coil (CHAR_DATA *ch, char *argument)
                 send_to_char("Coil around whom?\n\r", ch);
                 return;
         }
-        
+
         if (arg[0] != '\0' && !(victim = get_char_room(ch, arg)))
         {
                 send_to_char("They aren't here.\n\r", ch);
                 return;
         }
-        
-        if (is_safe (ch, victim)) 
+
+        if (is_safe (ch, victim))
                 return;
-        
-        if (victim->position > POS_STUNNED) 
+
+        if (victim->position > POS_STUNNED)
         {
-                if (!victim->fighting) 
+                if (!victim->fighting)
                         set_fighting(victim, ch);
-    
+
                 victim->position = POS_FIGHTING;
-        
-                if (!ch->fighting) 
+
+                if (!ch->fighting)
                         set_fighting(ch, victim);
         }
-        
-        if (is_affected(victim, gsn_coil)) 
+
+        if (is_affected(victim, gsn_coil))
         {
                 send_to_char("Do that again and you will never untangle yourself...\n\r", ch);
                 return;
         }
 
         WAIT_STATE(ch, skill_table[gsn_coil].beats);
-  
-        if (IS_NPC(ch) || number_percent() < ch->pcdata->learned[gsn_coil]) 
+
+        if (IS_NPC(ch) || number_percent() < ch->pcdata->learned[gsn_coil])
         {
-                act ("You coil your body around $N.", ch, NULL, victim, TO_CHAR); 
+                act ("You coil your body around $N.", ch, NULL, victim, TO_CHAR);
                 act ("$n encoils you in $s flesh - you are trapped!", ch, NULL, victim, TO_VICT);
                 act ("$n coils $s length about $N.", ch, NULL, victim, TO_NOTVICT);
                 arena_commentary("$n coils about $N.", ch, victim);
-                
+
                 WAIT_STATE(ch, 1 * PULSE_VIOLENCE);
-                victim->position = POS_RESTING; 
+                victim->position = POS_RESTING;
                 WAIT_STATE(victim, 2 * PULSE_VIOLENCE);
-        
+
                 af.type      = gsn_coil;
                 af.duration  = -1;
                 af.location  = APPLY_NONE;
                 af.modifier  = 0;
                 af.bitvector = AFF_HOLD;
                 affect_to_char(victim, &af);
-                
-                af.location = APPLY_HITROLL; 
+
+                af.location = APPLY_HITROLL;
                 af.bitvector = 0;
                 af.modifier = get_curr_str(ch) / 2;
                 affect_to_char(victim, &af);
-        } 
-        else 
+        }
+        else
                 send_to_char("You fail to encoil your target.\n\r",ch);
 }
 
 
-void do_constrict (CHAR_DATA *ch, char *argument) 
+void do_constrict (CHAR_DATA *ch, char *argument)
 {
         CHAR_DATA *victim;
 
         if ( IS_NPC( ch ) )
                 return;
 
-        if (!CAN_DO(ch, gsn_constrict)) 
+        if (!CAN_DO(ch, gsn_constrict))
         {
                 send_to_char("Huh?\n\r", ch);
                 return;
         }
 
-        if (ch->form != FORM_SNAKE) 
+        if (ch->form != FORM_SNAKE)
         {
                 send_to_char("You are not in the correct form.\n\r", ch);
                 return;
         }
-        
+
         if (!(victim = ch->fighting))
         {
                 send_to_char("You aren't fighting anyone.\n\r", ch);
-                return; 
+                return;
         }
-        
-        if (!is_affected(victim, gsn_coil)) 
+
+        if (!is_affected(victim, gsn_coil))
         {
                 send_to_char("You need to encoil them first!\n\r", ch);
                 return;
@@ -600,12 +600,12 @@ void do_constrict (CHAR_DATA *ch, char *argument)
         WAIT_STATE(ch, skill_table[gsn_constrict].beats);
 
         send_to_char("You {Gconstrict{x your opponent in your coils!\n\r", ch);
-        damage(ch, victim, number_range(ch->level * 2, ch->level * 7/2), gsn_constrict, FALSE); 
+        damage(ch, victim, number_range(ch->level * 2, ch->level * 7/2), gsn_constrict, FALSE);
 }
 
 
 
-void do_strangle (CHAR_DATA *ch, char *argument) 
+void do_strangle (CHAR_DATA *ch, char *argument)
 {
         CHAR_DATA *victim;
         int base_damage;
@@ -613,25 +613,25 @@ void do_strangle (CHAR_DATA *ch, char *argument)
         if (IS_NPC(ch))
                 return;
 
-        if (!CAN_DO(ch, gsn_strangle)) 
+        if (!CAN_DO(ch, gsn_strangle))
         {
                 send_to_char("Huh?\n\r", ch);
                 return;
         }
 
-        if (ch->form != FORM_SNAKE) 
+        if (ch->form != FORM_SNAKE)
         {
                 send_to_char("You are not in the correct form.\n\r",ch);
                 return;
         }
-        
+
         if (!(victim = ch->fighting))
         {
                 send_to_char("You aren't fighting anyone.\n\r", ch);
-                return; 
+                return;
         }
 
-        if (!is_affected(victim, gsn_coil)) 
+        if (!is_affected(victim, gsn_coil))
         {
                 send_to_char("You need to encoil them first!\n\r", ch);
                 return;
@@ -640,36 +640,36 @@ void do_strangle (CHAR_DATA *ch, char *argument)
         WAIT_STATE(ch, skill_table[gsn_strangle].beats);
 
         base_damage = number_range (2 * ch->level, 5 * ch->level);
-        
-        if (victim->hit > (victim->max_hit / 2)) 
+
+        if (victim->hit > (victim->max_hit / 2))
         {
                 send_to_char("You attempt to wrap your coils around your victim's neck, but fail.\n\r",ch);
-                return; 
+                return;
         }
-        
-        if (victim->hit < (victim->max_hit / 10)) 
-        { 
+
+        if (victim->hit < (victim->max_hit / 10))
+        {
                 damage(ch, victim, base_damage * 3, gsn_strangle, FALSE);
-                return; 
+                return;
         }
-        
-        if (victim->hit < (victim->max_hit / 4)) 
+
+        if (victim->hit < (victim->max_hit / 4))
         {
                 damage(ch, victim, base_damage * 2, gsn_strangle, FALSE);
-                return; 
+                return;
         }
-        
-        if (victim->hit < (victim->max_hit / 3)) 
+
+        if (victim->hit < (victim->max_hit / 3))
         {
                 damage(ch, victim, base_damage * 1.5, gsn_strangle, FALSE);
-                return; 
+                return;
         }
-        
+
         damage(ch, victim, base_damage, gsn_strangle, FALSE);
 }
 
 
-void do_morph_snake (CHAR_DATA *ch, bool to_form) 
+void do_morph_snake (CHAR_DATA *ch, bool to_form)
 {
         AFFECT_DATA af;
         OBJ_DATA *bite;
@@ -680,7 +680,7 @@ void do_morph_snake (CHAR_DATA *ch, bool to_form)
                 obj_to_char(bite, ch);
                 form_equip_char(ch, bite, WEAR_WIELD);
 
-                if (ch->pcdata->learned[gsn_form_snake] > 30) 
+                if (ch->pcdata->learned[gsn_form_snake] > 30)
                 {
                         affect_strip(ch, gsn_swim);
                         send_to_char("Your new form enables you to swim.\n\r", ch);
@@ -693,9 +693,9 @@ void do_morph_snake (CHAR_DATA *ch, bool to_form)
                         affect_to_char(ch, &af);
                 }
 
-                if (ch->pcdata->learned[gsn_form_snake] > 50) 
+                if (ch->pcdata->learned[gsn_form_snake] > 50)
                 {
-                        
+
                         send_to_char("Your new form enables you to breathe underwater.\n\r", ch);
                         affect_strip(ch, gsn_breathe_water);
                         af.type = gsn_breathe_water;
@@ -704,10 +704,10 @@ void do_morph_snake (CHAR_DATA *ch, bool to_form)
                 }
         }
         else
-        {      
+        {
 
                 bite = get_obj_wear(ch, "bite");
-                if (bite) 
+                if (bite)
                 {
                         unequip_char(ch, bite);
                         extract_obj(bite);
@@ -720,23 +720,23 @@ void do_morph_snake (CHAR_DATA *ch, bool to_form)
 }
 
 
-void do_morph_scorpion (CHAR_DATA *ch, bool to_form) 
+void do_morph_scorpion (CHAR_DATA *ch, bool to_form)
 {
         OBJ_DATA *sting;
         AFFECT_DATA *paf;
-        
-        if (to_form) 
+
+        if (to_form)
         {
                 sting = create_object(get_obj_index(OBJ_SCORPION_STING), ch->level);
-                
-                if (!affect_free) 
+
+                if (!affect_free)
                         paf = alloc_perm(sizeof(*paf));
-                else 
+                else
                 {
                         paf = affect_free;
                         affect_free = affect_free->next;
                 }
-                
+
                 paf->type = gsn_morph;
                 paf->duration = -1;
                 paf->location = APPLY_HITROLL;
@@ -744,15 +744,15 @@ void do_morph_scorpion (CHAR_DATA *ch, bool to_form)
                 paf->bitvector = 0;
                 paf->next = sting->affected;
                 sting->affected = paf;
-                
-                if (!affect_free) 
+
+                if (!affect_free)
                         paf = alloc_perm(sizeof(*paf));
                 else
                 {
                         paf = affect_free;
                         affect_free = affect_free->next;
                 }
-                
+
                 paf->type = gsn_morph;
                 paf->duration = -1;
                 paf->location = APPLY_DAMROLL;
@@ -760,16 +760,16 @@ void do_morph_scorpion (CHAR_DATA *ch, bool to_form)
                 paf->bitvector = 0;
                 paf->next = sting->affected;
                 sting->affected = paf;
-                
+
                 obj_to_char(sting, ch);
                 form_equip_char(ch, sting, WEAR_WIELD);
-                
+
                 send_to_char("You may backstab with your stinger...\n\r", ch);
         }
-        else 
+        else
         {
                 sting = get_obj_wear(ch, "sting");
-                if (sting) 
+                if (sting)
                 {
                         unequip_char(ch, sting);
                         extract_obj(sting);
@@ -778,41 +778,41 @@ void do_morph_scorpion (CHAR_DATA *ch, bool to_form)
 }
 
 
-void do_venom (CHAR_DATA *ch, char *argument) 
+void do_venom (CHAR_DATA *ch, char *argument)
 {
-        CHAR_DATA *victim;     
-        
-        if (IS_NPC(ch)) 
+        CHAR_DATA *victim;
+
+        if (IS_NPC(ch))
                 return;
-        
-        if (!CAN_DO(ch, gsn_venom)) 
+
+        if (!CAN_DO(ch, gsn_venom))
         {
                 send_to_char("What do you think you are, a spider?\n\r", ch);
                 return;
         }
-        
-        if (ch->form != FORM_SPIDER) 
+
+        if (ch->form != FORM_SPIDER)
         {
                 send_to_char("You are not in the correct form.\n\r", ch);
                 return;
         }
-        
+
         if (!(victim = ch->fighting))
         {
                 send_to_char("You are not fighting anyone.\n\r", ch);
                 return;
         }
-  
+
         WAIT_STATE(ch, skill_table[gsn_venom].beats);
         act ("You bite $N!",  ch, NULL, victim, TO_CHAR);
         act ("$n bites you!", ch, NULL, victim, TO_VICT);
         act ("$n bites $N!",  ch, NULL, victim, TO_NOTVICT);
-        
+
         spell_poison (gsn_venom, ch->level, ch, victim);
 }
 
 
-void do_web (CHAR_DATA *ch, char *argument) 
+void do_web (CHAR_DATA *ch, char *argument)
 {
         CHAR_DATA *victim;
         char arg[MAX_INPUT_LENGTH];
@@ -820,68 +820,68 @@ void do_web (CHAR_DATA *ch, char *argument)
 
         if (IS_NPC(ch))
                 return;
-        
-        if (!CAN_DO(ch, gsn_web)) 
+
+        if (!CAN_DO(ch, gsn_web))
         {
                 send_to_char("Huh?\n\r", ch);
                 return;
         }
-        
-        if (ch->form != FORM_SPIDER) 
+
+        if (ch->form != FORM_SPIDER)
         {
                 send_to_char("You are not in the correct form.\n\r", ch);
                 return;
         }
 
         WAIT_STATE(ch, 2);  /* Not too much spam thanks */
-        
+
         one_argument (argument, arg);
-        
-        if (arg[0] == '\0') 
+
+        if (arg[0] == '\0')
         {
                 send_to_char("Whom do you want to trap in your web?\n\r", ch);
                 return;
         }
-        
-        if (!(victim = get_char_room(ch, arg))) 
+
+        if (!(victim = get_char_room(ch, arg)))
         {
                 send_to_char("They aren't here.\n\r", ch);
                 return;
         }
-        
-        if (IS_AFFECTED(victim, AFF_HOLD)) 
+
+        if (IS_AFFECTED(victim, AFF_HOLD))
         {
                 act ("$N is already stuck here by some means.", ch, NULL, victim, TO_CHAR);
                 return;
         }
-        
-        if (victim == ch) 
+
+        if (victim == ch)
         {
                 send_to_char("You want to spin a web around yourself?\n\r", ch);
                 return;
         }
- 
-        if (victim->fighting) 
+
+        if (victim->fighting)
         {
                 send_to_char("You cannot web a fighting person.\n\r", ch);
                 return;
         }
-        
-        if (is_safe(ch, victim)) 
+
+        if (is_safe(ch, victim))
                 return;
-        
+
         WAIT_STATE(ch, PULSE_VIOLENCE);
- 
+
         /*
          * Web gets better.
          */
 
-        chance = 50 + (ch->pcdata->learned[gsn_web] / 2); 
+        chance = 50 + (ch->pcdata->learned[gsn_web] / 2);
         chance += (ch->level - victim->level) * 3;
 
         chance = URANGE(5, chance, 95);
 
-        if (number_percent() < chance) 
+        if (number_percent() < chance)
         {
                 AFFECT_DATA af;
                 act ("You skillfully spin a sticky web around $N, trapping $M here!",
@@ -889,13 +889,13 @@ void do_web (CHAR_DATA *ch, char *argument)
                 act ("$n skillfully spins a sticky web around $N, trapping $M here!",
                      ch, NULL, victim, TO_ROOM);
                 arena_commentary("$n traps $N in a sticky web.", ch, victim);
-                
+
                 af.type = gsn_web;
                 af.duration = 4 + (ch->level / 20);
                 af.location = APPLY_HITROLL;
                 af.modifier = -8;
                 af.bitvector = AFF_HOLD;
-                
+
                 affect_to_char(victim, &af);
 
                 WAIT_STATE(victim, PULSE_VIOLENCE);
@@ -903,7 +903,7 @@ void do_web (CHAR_DATA *ch, char *argument)
                 check_group_bonus(ch);
 
         }
-        else 
+        else
         {
                 act ("$n attempts to spin a web around $N, but $N breaks free!",
                      ch, NULL, victim, TO_ROOM);
@@ -913,8 +913,8 @@ void do_web (CHAR_DATA *ch, char *argument)
 
                 /*
                  * Web gets worse.
-                 */     
-        
+                 */
+
                 if (!IS_NPC(victim))
                 {
                         damage(ch, victim, 0, gsn_web, FALSE);
@@ -936,7 +936,7 @@ void do_web (CHAR_DATA *ch, char *argument)
                                         return;
                                 }
                         }
-                        else 
+                        else
                         {
                                 if (!number_bits(2))
                                 {
@@ -944,17 +944,17 @@ void do_web (CHAR_DATA *ch, char *argument)
                                         return;
                                 }
                         }
-                }               
+                }
 
         }
 }
 
 
-void do_morph_spider (CHAR_DATA *ch, bool to_form) 
+void do_morph_spider (CHAR_DATA *ch, bool to_form)
 {
         OBJ_DATA *mandibles;
-        
-        if (to_form) 
+
+        if (to_form)
         {
                 mandibles = create_object(get_obj_index(OBJ_SPIDER_MANDIBLES), ch->level);
                 if (mandibles)
@@ -963,10 +963,10 @@ void do_morph_spider (CHAR_DATA *ch, bool to_form)
                         form_equip_char(ch, mandibles, WEAR_WIELD);
                 }
         }
-        else 
+        else
         {
                 mandibles = get_obj_wear(ch, "mandibles");
-                if (mandibles) 
+                if (mandibles)
                 {
                         unequip_char(ch, mandibles);
                         extract_obj(mandibles);
@@ -975,27 +975,27 @@ void do_morph_spider (CHAR_DATA *ch, bool to_form)
 }
 
 
-void do_forage(CHAR_DATA *ch,  char *argument) 
+void do_forage(CHAR_DATA *ch,  char *argument)
 {
         if (IS_NPC(ch))
                 return;
-        
-        if (!CAN_DO(ch, gsn_forage) && ch->race != RACE_WILD_ELF) 
+
+        if (!CAN_DO(ch, gsn_forage) && ch->race != RACE_WILD_ELF)
         {
                 send_to_char("Huh?\n\r", ch);
                 return;
         }
-        
-        if (ch->class == CLASS_SHAPE_SHIFTER && ch->form != FORM_BEAR && ch->race != RACE_WILD_ELF) 
+
+        if (ch->class == CLASS_SHAPE_SHIFTER && ch->form != FORM_BEAR && ch->race != RACE_WILD_ELF)
         {
                 send_to_char("You are not in the correct form.\n\r",ch);
                 return;
         }
-        
-        if (ch->in_room->sector_type != SECT_FIELD 
-            && ch->in_room->sector_type != SECT_FOREST 
-            && ch->in_room->sector_type != SECT_DESERT 
-            && ch->in_room->sector_type != SECT_MOUNTAIN 
+
+        if (ch->in_room->sector_type != SECT_FIELD
+            && ch->in_room->sector_type != SECT_FOREST
+            && ch->in_room->sector_type != SECT_DESERT
+            && ch->in_room->sector_type != SECT_MOUNTAIN
             && ch->in_room->sector_type != SECT_HILLS)
         {
                 send_to_char("Not in this type of terrain.\n\r",ch);
@@ -1003,23 +1003,23 @@ void do_forage(CHAR_DATA *ch,  char *argument)
         }
 
         WAIT_STATE(ch, skill_table[gsn_forage].beats);
-        
-        if (number_percent() > ch->pcdata->learned[gsn_forage]) 
+
+        if (number_percent() > ch->pcdata->learned[gsn_forage])
         {
                 send_to_char("You forage around for food but find nothing.\n\r", ch);
                 return;
         }
-                
+
         send_to_char("You forage about and find some food to eat.\n\r", ch);
         ch->pcdata->condition[COND_FULL] += UMIN(30, 48 - ch->pcdata->condition[COND_FULL]);
 }
 
 
-void do_morph_bear (CHAR_DATA *ch, bool to_form) 
+void do_morph_bear (CHAR_DATA *ch, bool to_form)
 {
         OBJ_DATA *claws;
 
-        if (to_form) 
+        if (to_form)
         {
                 claws = create_object(get_obj_index(OBJ_BEAR_CLAWS), ch->level);
                 if (claws)
@@ -1030,7 +1030,7 @@ void do_morph_bear (CHAR_DATA *ch, bool to_form)
                         form_equip_char(ch, claws, WEAR_WIELD);
                 }
         }
-        else        
+        else
         {
 
                 /*
@@ -1040,7 +1040,7 @@ void do_morph_bear (CHAR_DATA *ch, bool to_form)
                  */
 
                 claws = get_obj_wear(ch, "sftclaws");
-                if (claws) 
+                if (claws)
                 {
                         unequip_char(ch, claws);
                         extract_obj(claws);
@@ -1049,65 +1049,65 @@ void do_morph_bear (CHAR_DATA *ch, bool to_form)
 }
 
 
-void do_bite (CHAR_DATA *ch, char *argument) 
+void do_bite (CHAR_DATA *ch, char *argument)
 {
         CHAR_DATA *victim;
-        
-        if (IS_NPC(ch)) 
+
+        if (IS_NPC(ch))
                 return;
-        
-        if (!CAN_DO(ch, gsn_bite)) 
+
+        if (!CAN_DO(ch, gsn_bite))
         {
                 send_to_char("What do you think you are, a tiger?\n\r", ch);
                 return;
         }
-        
-        if (!(ch->form == FORM_TIGER)) 
+
+        if (!(ch->form == FORM_TIGER))
         {
                 send_to_char("You are not in the correct form.\n\r", ch);
                 return;
         }
-        
+
         if (!(victim = ch->fighting))
         {
                 send_to_char("You are not fighting anyone.\n\r", ch);
                 return;
         }
-        
+
         WAIT_STATE(ch, skill_table[gsn_bite].beats);
-        
+
         send_to_char("You attempt to sink your fangs into your victim.\n\r", ch);
-        
+
         if (number_percent() < ch->pcdata->learned[gsn_bite])
         {
                 arena_commentary("$n bites $N.", ch, victim);
                 damage(ch,victim,number_range(ch->level*3, ch->level*5), gsn_bite, FALSE);
         }
-        else 
+        else
                 damage (ch, victim, 0, gsn_bite, FALSE);
 }
 
 
-void do_wolfbite (CHAR_DATA *ch, char *argument) 
+void do_wolfbite (CHAR_DATA *ch, char *argument)
 {
         CHAR_DATA       *victim;
         char            arg [MAX_INPUT_LENGTH];
-                
-        if (IS_NPC(ch)) 
+
+        if (IS_NPC(ch))
                 return;
-        
-        if (!CAN_DO(ch, gsn_wolfbite)) 
+
+        if (!CAN_DO(ch, gsn_wolfbite))
         {
                 send_to_char("What do you think you are, a wolf?\n\r", ch);
                 return;
         }
-        
+
         if (!(ch->form == FORM_WOLF || ch->form == FORM_DIREWOLF))
         {
                 send_to_char("You are not in the correct form.\n\r",ch);
                 return;
         }
-        
+
         one_argument(argument, arg);
 
         if (!(victim = ch->fighting))
@@ -1117,79 +1117,32 @@ void do_wolfbite (CHAR_DATA *ch, char *argument)
                         send_to_char("Wolfbite whom?\n\r", ch);
                         return;
                 }
-        
+
                 if (!(victim = get_char_room(ch, arg)))
                 {
                         send_to_char("They aren't here.\n\r", ch);
                         return;
                 }
         }
-        
-        if (is_safe (ch, victim)) 
+
+        if (is_safe (ch, victim))
                 return;
-        
+
         WAIT_STATE(ch, skill_table[gsn_wolfbite].beats);
-        
+
         send_to_char("You attempt to sink your fangs into your victim.\n\r", ch);
-        
+
         if (number_percent() < ch->pcdata->learned[gsn_wolfbite])
         {
                 arena_commentary("$n bites $N.", ch, victim);
                 damage(ch, victim, number_range(ch->level*3, ch->level*5), gsn_wolfbite, FALSE);
         }
-        else 
+        else
                 damage (ch, victim, 0, gsn_wolfbite, FALSE);
 }
 
 
-void do_maul (CHAR_DATA *ch, char *argument) 
-{
-        CHAR_DATA *victim;
-        int percent;
-        int count;
-        
-        if (IS_NPC(ch)) 
-                return;
-        
-        if (!CAN_DO(ch, gsn_maul)) 
-        {
-                send_to_char("What do you think you are, a tiger?\n\r", ch);
-                return;
-        }
-        
-        if (!(ch->form == FORM_TIGER || ch->form == FORM_GRIFFIN))
-        {
-                send_to_char("You are not in the correct form.\n\r",ch);
-                return;
-        }
-        
-        if (!(victim = ch->fighting))
-        {
-                send_to_char("You are not fighting anyone.\n\r", ch);
-                return;
-        }
-        
-        WAIT_STATE(ch, skill_table[gsn_maul].beats);
-        arena_commentary("$n mauls $N.", ch, victim);
-        percent = ch->pcdata->learned[gsn_maul];
-        count = 0;
-        
-        while (!count || number_percent() < percent) 
-        {
-                damage(ch, victim, number_range(ch->level * 2, ch->level * 3), gsn_maul, FALSE);
-                
-                if (victim->position == POS_DEAD || ch->in_room != victim->in_room) 
-                        return;
-                
-                if (++count == 8)
-                        return;
-                
-                percent -= 7;
-        }
-}
-
-
-void do_ravage(CHAR_DATA *ch, char *argument) 
+void do_maul (CHAR_DATA *ch, char *argument)
 {
         CHAR_DATA *victim;
         int percent;
@@ -1197,65 +1150,112 @@ void do_ravage(CHAR_DATA *ch, char *argument)
 
         if (IS_NPC(ch))
                 return;
- 
-        if (!CAN_DO(ch, gsn_ravage)) 
+
+        if (!CAN_DO(ch, gsn_maul))
         {
-                send_to_char("What do you think you are, a wolf?\n\r", ch);
+                send_to_char("What do you think you are, a tiger?\n\r", ch);
                 return;
         }
-        
-        if (!(ch->form == FORM_WOLF || ch->form == FORM_DIREWOLF))
+
+        if (!(ch->form == FORM_TIGER || ch->form == FORM_GRIFFIN))
         {
                 send_to_char("You are not in the correct form.\n\r",ch);
                 return;
         }
-        
+
         if (!(victim = ch->fighting))
         {
                 send_to_char("You are not fighting anyone.\n\r", ch);
                 return;
         }
-        
-        WAIT_STATE(ch, skill_table[gsn_ravage].beats);
-        arena_commentary("$n ravages $N.", ch, victim);
-        
-        percent = ch->pcdata->learned[gsn_ravage];
+
+        WAIT_STATE(ch, skill_table[gsn_maul].beats);
+        arena_commentary("$n mauls $N.", ch, victim);
+        percent = ch->pcdata->learned[gsn_maul];
         count = 0;
 
-        while (!count || number_percent() < percent) 
+        while (!count || number_percent() < percent)
         {
-                damage(ch, victim, number_range(ch->level * 2, ch->level * 3), gsn_ravage, FALSE);
-                
-                if (victim->position == POS_DEAD || ch->in_room != victim->in_room) 
+                damage(ch, victim, number_range(ch->level * 2, ch->level * 3), gsn_maul, FALSE);
+
+                if (victim->position == POS_DEAD || ch->in_room != victim->in_room)
                         return;
-                
+
                 if (++count == 8)
                         return;
-                
+
                 percent -= 7;
         }
 }
 
 
-void do_morph_tiger (CHAR_DATA *ch, bool to_form) 
+void do_ravage(CHAR_DATA *ch, char *argument)
+{
+        CHAR_DATA *victim;
+        int percent;
+        int count;
+
+        if (IS_NPC(ch))
+                return;
+
+        if (!CAN_DO(ch, gsn_ravage))
+        {
+                send_to_char("What do you think you are, a wolf?\n\r", ch);
+                return;
+        }
+
+        if (!(ch->form == FORM_WOLF || ch->form == FORM_DIREWOLF))
+        {
+                send_to_char("You are not in the correct form.\n\r",ch);
+                return;
+        }
+
+        if (!(victim = ch->fighting))
+        {
+                send_to_char("You are not fighting anyone.\n\r", ch);
+                return;
+        }
+
+        WAIT_STATE(ch, skill_table[gsn_ravage].beats);
+        arena_commentary("$n ravages $N.", ch, victim);
+
+        percent = ch->pcdata->learned[gsn_ravage];
+        count = 0;
+
+        while (!count || number_percent() < percent)
+        {
+                damage(ch, victim, number_range(ch->level * 2, ch->level * 3), gsn_ravage, FALSE);
+
+                if (victim->position == POS_DEAD || ch->in_room != victim->in_room)
+                        return;
+
+                if (++count == 8)
+                        return;
+
+                percent -= 7;
+        }
+}
+
+
+void do_morph_tiger (CHAR_DATA *ch, bool to_form)
 {
         OBJ_DATA *fangs;
         OBJ_DATA *claws;
         AFFECT_DATA *paf;
-        
-        if (to_form) 
+
+        if (to_form)
         {
                 claws = create_object(get_obj_index(OBJ_TIGER_CLAWS), ch->level);
                 fangs = create_object(get_obj_index(OBJ_TIGER_FANGS), ch->level);
-                
-                if (!affect_free) 
+
+                if (!affect_free)
                         paf = alloc_perm(sizeof(*paf));
-                else 
+                else
                 {
                         paf = affect_free;
                         affect_free = affect_free->next;
                 }
-                
+
                 paf->type = gsn_morph;
                 paf->duration = -1;
                 paf->location = APPLY_HITROLL;
@@ -1263,15 +1263,15 @@ void do_morph_tiger (CHAR_DATA *ch, bool to_form)
                 paf->bitvector = 0;
                 paf->next = claws->affected;
                 claws->affected = paf;
-                
-                if (!affect_free) 
+
+                if (!affect_free)
                         paf = alloc_perm(sizeof(*paf));
-                else 
+                else
                 {
                         paf = affect_free;
                         affect_free = affect_free->next;
                 }
-                
+
                 paf->type = gsn_morph;
                 paf->duration = -1;
                 paf->location = APPLY_DAMROLL;
@@ -1279,18 +1279,18 @@ void do_morph_tiger (CHAR_DATA *ch, bool to_form)
                 paf->bitvector = 0;
                 paf->next = claws->affected;
                 claws->affected = paf;
-                
+
                 obj_to_char(claws, ch);
                 form_equip_char(ch, claws, WEAR_DUAL);
-                
-                if (!affect_free) 
+
+                if (!affect_free)
                         paf = alloc_perm(sizeof(*paf));
-                else 
+                else
                 {
                         paf = affect_free;
                         affect_free = affect_free->next;
                 }
-                
+
                 paf->type = gsn_morph;
                 paf->duration = -1;
                 paf->location = APPLY_DAMROLL;
@@ -1298,7 +1298,7 @@ void do_morph_tiger (CHAR_DATA *ch, bool to_form)
                 paf->bitvector = 0;
                 paf->next = fangs->affected;
                 fangs->affected = paf;
-                
+
                 obj_to_char(fangs, ch);
                 form_equip_char(ch, fangs, WEAR_WIELD);
         }
@@ -1306,13 +1306,13 @@ void do_morph_tiger (CHAR_DATA *ch, bool to_form)
         {
                 claws = get_obj_wear(ch, "sftclaws");
                 fangs = get_obj_wear(ch, "sftfangs");
-                
-                if (claws) 
+
+                if (claws)
                 {
                         unequip_char(ch, claws);
                         extract_obj(claws);
                 }
-                if (fangs) 
+                if (fangs)
                 {
                         unequip_char(ch, fangs);
                         extract_obj(fangs);
@@ -1328,14 +1328,14 @@ void do_morph_wolf (CHAR_DATA *ch, bool to_form)
         AFFECT_DATA *paf;
         AFFECT_DATA af;
 
-        if (to_form) 
+        if (to_form)
         {
                 claws = create_object(get_obj_index(OBJ_TIGER_CLAWS), ch->level);
                 fangs = create_object(get_obj_index(OBJ_TIGER_FANGS), ch->level);
 
-                if (!affect_free) 
+                if (!affect_free)
                         paf = alloc_perm(sizeof(*paf));
-                else 
+                else
                 {
                         paf = affect_free;
                         affect_free = affect_free->next;
@@ -1349,9 +1349,9 @@ void do_morph_wolf (CHAR_DATA *ch, bool to_form)
                 paf->next = claws->affected;
                 claws->affected = paf;
 
-                if (!affect_free) 
+                if (!affect_free)
                         paf = alloc_perm(sizeof(*paf));
-                else 
+                else
                 {
                         paf = affect_free;
                         affect_free = affect_free->next;
@@ -1368,9 +1368,9 @@ void do_morph_wolf (CHAR_DATA *ch, bool to_form)
                 obj_to_char(claws, ch);
                 form_equip_char(ch, claws, WEAR_DUAL);
 
-                if (!affect_free) 
+                if (!affect_free)
                         paf = alloc_perm(sizeof(*paf));
-                else 
+                else
                 {
                         paf = affect_free;
                         affect_free = affect_free->next;
@@ -1396,7 +1396,7 @@ void do_morph_wolf (CHAR_DATA *ch, bool to_form)
                 af.modifier  = 0;
                 af.bitvector = AFF_INFRARED;
                 affect_to_char(ch, &af);
-                
+
                 affect_strip(ch, gsn_detect_hidden);
                 send_to_char("Your new form causes your awareness to improve.\n\r", ch);
 
@@ -1406,7 +1406,7 @@ void do_morph_wolf (CHAR_DATA *ch, bool to_form)
                 af.modifier  = 0;
                 af.bitvector = AFF_DETECT_HIDDEN;
                 affect_to_char(ch, &af);
-                
+
                 affect_strip(ch, gsn_detect_invis);
                 send_to_char("Your new form causes your senses to rocket.\n\r", ch);
 
@@ -1416,7 +1416,7 @@ void do_morph_wolf (CHAR_DATA *ch, bool to_form)
                 af.modifier  = 0;
                 af.bitvector = AFF_DETECT_INVIS;
                 affect_to_char(ch, &af);
-                
+
                 af.type      = gsn_detect_sneak;
                 af.duration  = -1;
                 af.location  = APPLY_NONE;
@@ -1424,17 +1424,17 @@ void do_morph_wolf (CHAR_DATA *ch, bool to_form)
                 af.bitvector = AFF_DETECT_SNEAK;
                 affect_to_char(ch, &af);
         }
-        else 
+        else
         {
                 claws = get_obj_wear(ch, "sftclaws");
                 fangs = get_obj_wear(ch, "sftfangs");
-                
-                if (claws) 
+
+                if (claws)
                 {
                         unequip_char(ch, claws);
                         extract_obj(claws);
                 }
-                if (fangs) 
+                if (fangs)
                 {
                         unequip_char(ch, fangs);
                         extract_obj(fangs);
@@ -1461,14 +1461,14 @@ void do_morph_direwolf (CHAR_DATA *ch, bool to_form)
         AFFECT_DATA *paf;
         AFFECT_DATA af;
 
-        if (to_form) 
+        if (to_form)
         {
                 claws = create_object(get_obj_index(OBJ_TIGER_CLAWS), ch->level);
                 fangs = create_object(get_obj_index(OBJ_TIGER_FANGS), ch->level);
 
-                if (!affect_free) 
+                if (!affect_free)
                         paf = alloc_perm(sizeof(*paf));
-                else 
+                else
                 {
                         paf = affect_free;
                         affect_free = affect_free->next;
@@ -1482,9 +1482,9 @@ void do_morph_direwolf (CHAR_DATA *ch, bool to_form)
                 paf->next = claws->affected;
                 claws->affected = paf;
 
-                if (!affect_free) 
+                if (!affect_free)
                         paf = alloc_perm(sizeof(*paf));
-                else 
+                else
                 {
                         paf = affect_free;
                         affect_free = affect_free->next;
@@ -1501,9 +1501,9 @@ void do_morph_direwolf (CHAR_DATA *ch, bool to_form)
                 obj_to_char(claws, ch);
                 form_equip_char(ch, claws, WEAR_DUAL);
 
-                if (!affect_free) 
+                if (!affect_free)
                         paf = alloc_perm(sizeof(*paf));
-                else 
+                else
                 {
                         paf = affect_free;
                         affect_free = affect_free->next;
@@ -1529,44 +1529,44 @@ void do_morph_direwolf (CHAR_DATA *ch, bool to_form)
                 af.modifier  = 0;
                 af.bitvector = AFF_INFRARED;
                 affect_to_char(ch, &af);
-                
+
                 affect_strip(ch, gsn_detect_hidden);
                 send_to_char("Your new form causes your awareness to improve.\n\r", ch);
 
                 af.type      = gsn_detect_hidden;
                 af.bitvector = AFF_DETECT_HIDDEN;
                 affect_to_char(ch, &af);
-                
+
                 affect_strip(ch, gsn_detect_invis);
                 send_to_char("Your new form causes your senses to rocket.\n\r", ch);
 
                 af.type      = gsn_detect_invis;
                 af.bitvector = AFF_DETECT_INVIS;
                 affect_to_char(ch, &af);
-                
+
                 affect_strip(ch, gsn_detect_sneak);
                 af.type      = gsn_detect_sneak;
                 af.bitvector = AFF_DETECT_SNEAK;
                 affect_to_char(ch, &af);
-                
+
                 affect_strip(ch, gsn_form_direwolf);
                 send_to_char("You are surrounded by a terrifying aura!\n\r", ch);
                 af.type      = gsn_form_direwolf;
                 af.bitvector = AFF_BATTLE_AURA;
                 affect_to_char(ch, &af);
-                
+
         }
-        else 
+        else
         {
                 claws = get_obj_wear(ch, "sftclaws");
                 fangs = get_obj_wear(ch, "sftfangs");
-                
-                if (claws) 
+
+                if (claws)
                 {
                         unequip_char(ch, claws);
                         extract_obj(claws);
                 }
-                if (fangs) 
+                if (fangs)
                 {
                         unequip_char(ch, fangs);
                         extract_obj(fangs);
@@ -1578,7 +1578,7 @@ void do_morph_direwolf (CHAR_DATA *ch, bool to_form)
                 affect_strip(ch, gsn_detect_invis);
                 REMOVE_BIT(ch->affected_by, AFF_DETECT_INVIS);
                 affect_strip(ch, gsn_detect_sneak);
-                affect_strip(ch, gsn_heighten);   
+                affect_strip(ch, gsn_heighten);
                 affect_strip(ch, gsn_form_direwolf);
                 affect_strip(ch, gsn_gaias_warning);
                 REMOVE_BIT(ch->affected_by, AFF_BATTLE_AURA);
@@ -1586,32 +1586,32 @@ void do_morph_direwolf (CHAR_DATA *ch, bool to_form)
 }
 
 
-void do_morph_hydra (CHAR_DATA *ch, bool to_form) 
+void do_morph_hydra (CHAR_DATA *ch, bool to_form)
 {
-        OBJ_DATA *teeth;   
+        OBJ_DATA *teeth;
 
         if (to_form)
         {
-                teeth = create_object(get_obj_index(OBJ_HYDRA_TEETH), ch->level);   
+                teeth = create_object(get_obj_index(OBJ_HYDRA_TEETH), ch->level);
                 teeth->value[1] *= 2;
                 teeth->value[2] *= 2;
-                
+
                 obj_to_char(teeth, ch);
                 form_equip_char(ch, teeth, WEAR_WIELD);
-                
-                if (ch->pcdata->learned[gsn_form_hydra] > 50) 
+
+                if (ch->pcdata->learned[gsn_form_hydra] > 50)
                         send_to_char("You can now breathe colour spray!\n\r",ch);
-                
+
                 if (ch->pcdata->learned[gsn_form_hydra] > 75)
                         send_to_char("You can now breathe fireballs!\n\r",ch);
-                
+
                 if (ch->pcdata->learned[gsn_form_hydra] > 85)
-                        send_to_char("You can now breathe acid blasts!\n\r",ch); 
+                        send_to_char("You can now breathe acid blasts!\n\r",ch);
         }
-        else 
+        else
         {
                 teeth = get_obj_wear(ch, "teeth");
-                if (teeth) 
+                if (teeth)
                 {
                         unequip_char(ch, teeth);
                         extract_obj(teeth);
@@ -1620,14 +1620,14 @@ void do_morph_hydra (CHAR_DATA *ch, bool to_form)
 }
 
 
-void do_morph_dragon (CHAR_DATA *ch, bool to_form) 
+void do_morph_dragon (CHAR_DATA *ch, bool to_form)
 {
         AFFECT_DATA af;
-        OBJ_DATA *fangs; 
+        OBJ_DATA *fangs;
         OBJ_DATA *claws;
         AFFECT_DATA *paf;
-        
-        if (to_form) 
+
+        if (to_form)
         {
                 if (ch->pcdata->learned[gsn_form_dragon] > 60
                     || ch->pcdata->learned[gsn_fly])
@@ -1636,7 +1636,7 @@ void do_morph_dragon (CHAR_DATA *ch, bool to_form)
                         affect_strip(ch, gsn_levitation);
                         REMOVE_BIT(ch->affected_by, AFF_FLYING);
                         send_to_char("Your new form enables you to fly.\n\r", ch);
-                        
+
                         af.type      = gsn_fly;
                         af.duration  = -1;
                         af.location  = APPLY_NONE;
@@ -1644,41 +1644,41 @@ void do_morph_dragon (CHAR_DATA *ch, bool to_form)
                         af.bitvector = AFF_FLYING;
                         affect_to_char(ch, &af);
                 }
-                
-                if (ch->pcdata->learned[gsn_form_dragon] > 75) 
+
+                if (ch->pcdata->learned[gsn_form_dragon] > 75)
                         send_to_char("You can now breathe lightning!\n\r",ch);
-    
-                if (ch->pcdata->learned[gsn_form_dragon] > 80) 
+
+                if (ch->pcdata->learned[gsn_form_dragon] > 80)
                         send_to_char("You can now breathe frost!\n\r",ch);
-    
-                if (ch->pcdata->learned[gsn_form_dragon] > 85) 
+
+                if (ch->pcdata->learned[gsn_form_dragon] > 85)
                         send_to_char("You can now breathe fire!\n\r",ch);
-    
-                if (ch->pcdata->learned[gsn_form_dragon] > 90) 
+
+                if (ch->pcdata->learned[gsn_form_dragon] > 90)
                         send_to_char("You can now breathe acid!\n\r",ch);
-    
-                if (ch->pcdata->learned[gsn_form_dragon] > 95) 
+
+                if (ch->pcdata->learned[gsn_form_dragon] > 95)
                         send_to_char("You can now breathe gas!\n\r",ch);
-    
-                if (ch->pcdata->learned[gsn_form_dragon] > 90) 
+
+                if (ch->pcdata->learned[gsn_form_dragon] > 90)
                 {
                         send_to_char ("You are surrounded by a terrifying aura!\n\r", ch);
                         affect_strip (ch, gsn_dragon_aura);
-                        
+
                         af.type         = gsn_dragon_aura;
                         af.duration     = -1;
                         af.modifier     = - ch->level;
                         af.bitvector    = 0;
                         af.location     = APPLY_AC;
                         affect_to_char (ch, &af);
-                        
+
                         af.type         = gsn_dragon_aura;
                         af.duration     = -1;
                         af.modifier     = ch->level / 8;
                         af.bitvector    = 0;
                         af.location     = APPLY_HITROLL;
                         affect_to_char (ch, &af);
-                        
+
                         af.type         = gsn_dragon_aura;
                         af.duration     = -1;
                         af.modifier     = 0;
@@ -1686,18 +1686,18 @@ void do_morph_dragon (CHAR_DATA *ch, bool to_form)
                         af.location     = APPLY_NONE;
                         affect_to_char (ch, &af);
                 }
-                
+
                 claws = create_object(get_obj_index(OBJ_DRAGON_CLAWS), ch->level);
-                fangs = create_object(get_obj_index(OBJ_DRAGON_CLAWS), ch->level); 
-                
-                if (!affect_free) 
+                fangs = create_object(get_obj_index(OBJ_DRAGON_CLAWS), ch->level);
+
+                if (!affect_free)
                         paf = alloc_perm(sizeof(*paf));
-                else 
+                else
                 {
                         paf = affect_free;
                         affect_free = affect_free->next;
                 }
- 
+
                 paf->type = gsn_morph;
                 paf->duration = -1;
                 paf->location = APPLY_HITROLL;
@@ -1705,15 +1705,15 @@ void do_morph_dragon (CHAR_DATA *ch, bool to_form)
                 paf->bitvector = 0;
                 paf->next = claws->affected;
                 claws->affected = paf;
- 
-                if (!affect_free) 
+
+                if (!affect_free)
                         paf = alloc_perm(sizeof(*paf));
-                else 
+                else
                 {
                         paf = affect_free;
                         affect_free = affect_free->next;
                 }
-                
+
                 paf->type = gsn_morph;
                 paf->duration = -1;
                 paf->location = APPLY_DAMROLL;
@@ -1721,7 +1721,7 @@ void do_morph_dragon (CHAR_DATA *ch, bool to_form)
                 paf->bitvector = 0;
                 paf->next = claws->affected;
                 claws->affected = paf;
-                
+
                 obj_to_char(claws, ch);
                 form_equip_char(ch, claws, WEAR_WIELD);
 
@@ -1732,7 +1732,7 @@ void do_morph_dragon (CHAR_DATA *ch, bool to_form)
                         paf = affect_free;
                         affect_free = affect_free->next;
                 }
- 
+
                 paf->type = gsn_morph;
                 paf->duration = -1;
                 paf->location = APPLY_DAMROLL;
@@ -1740,27 +1740,27 @@ void do_morph_dragon (CHAR_DATA *ch, bool to_form)
                 paf->bitvector = 0;
                 paf->next = fangs->affected;
                 fangs->affected = paf;
-                
+
                 obj_to_char(fangs, ch);
                 form_equip_char(ch, fangs, WEAR_DUAL);
         }
-        else 
+        else
         {
                 affect_strip(ch, gsn_fly);
                 affect_strip(ch, gsn_levitation);
                 affect_strip(ch, gsn_dragon_aura);
                 REMOVE_BIT(ch->affected_by, AFF_FLYING);
-                
+
                 claws = get_obj_wear(ch, "sftclaws");
-                fangs = get_obj_wear(ch, "sftfangs"); 
-                
-                if (claws) 
+                fangs = get_obj_wear(ch, "sftfangs");
+
+                if (claws)
                 {
                         unequip_char(ch, claws);
                         extract_obj(claws);
                 }
-                
-                if (fangs) 
+
+                if (fangs)
                 {
                         unequip_char(ch, fangs);
                         extract_obj(fangs);
@@ -1769,19 +1769,19 @@ void do_morph_dragon (CHAR_DATA *ch, bool to_form)
 }
 
 
-void do_morph_phoenix (CHAR_DATA *ch, bool to_form) 
+void do_morph_phoenix (CHAR_DATA *ch, bool to_form)
 {
         AFFECT_DATA af;
- 
+
         if (to_form)
         {
-                if ((ch->pcdata->learned[gsn_form_phoenix] > 40) 
-                    || (ch->pcdata->learned[gsn_fly])) 
+                if ((ch->pcdata->learned[gsn_form_phoenix] > 40)
+                    || (ch->pcdata->learned[gsn_fly]))
                 {
                         affect_strip(ch, gsn_fly);
                         affect_strip(ch, gsn_levitation);
                         send_to_char("Your new form enables you to fly.\n\r", ch);
- 
+
                         af.type      = gsn_fly;
                         af.duration  = -1;
                         af.location  = APPLY_NONE;
@@ -1789,32 +1789,32 @@ void do_morph_phoenix (CHAR_DATA *ch, bool to_form)
                         af.bitvector = AFF_FLYING;
                         affect_to_char(ch, &af);
                 }
-                
-                if (ch->pcdata->learned[gsn_form_phoenix] > 80) 
+
+                if (ch->pcdata->learned[gsn_form_phoenix] > 80)
                 {
                         affect_strip(ch, gsn_fireshield);
                         send_to_char("The air around your form bursts into flame!\n\r", ch);
-                        
+
                         af.type      = gsn_fireshield;
                         af.duration  = -1;
                         af.location  = APPLY_NONE;
                         af.modifier  = 0;
                         af.bitvector = AFF_FLAMING;
                         affect_to_char(ch, &af);
-                        
+
                         affect_strip(ch, gsn_resist_heat);
                         send_to_char("You resist heat and flame!\n\r", ch);
-                        
+
                         af.type  = gsn_resist_heat;
                         af.bitvector = 0;
                         affect_to_char(ch, &af);
                 }
-                
-                if (ch->pcdata->learned[gsn_form_phoenix] > 95) 
-                {   
+
+                if (ch->pcdata->learned[gsn_form_phoenix] > 95)
+                {
                         affect_strip(ch, gsn_globe);
                         send_to_char("A scintillating globe forms around you!\n\r", ch);
-                        
+
                         af.type      = gsn_globe;
                         af.duration  = -1;
                         af.location  = APPLY_NONE;
@@ -1822,8 +1822,8 @@ void do_morph_phoenix (CHAR_DATA *ch, bool to_form)
                         af.bitvector = AFF_GLOBE;
                         affect_to_char(ch, &af);
                 }
-        } 
-        else 
+        }
+        else
         {
                 affect_strip(ch, gsn_fly);
                 affect_strip(ch, gsn_levitation);
@@ -1834,40 +1834,39 @@ void do_morph_phoenix (CHAR_DATA *ch, bool to_form)
                 REMOVE_BIT(ch->affected_by, AFF_GLOBE);
                 affect_strip(ch, gsn_resist_heat);
         }
-} 
+}
 
 
-void do_morph_fly (CHAR_DATA *ch, bool to_form) 
+void do_morph_fly (CHAR_DATA *ch, bool to_form)
 {
         AFFECT_DATA af;
         AFFECT_DATA *paf;
-        
+
         if (to_form)
         {
                 for ( paf = ch->affected; paf; paf = paf->next )
                 {
-                        
+
                         if ( paf->deleted )
                                 continue;
-                        
+
                         if (paf->duration < 0 )
                                 continue;
-                        
+
                         if (effect_is_prayer(paf))
                                 continue;
-                        
+
                         affect_remove( ch, paf );
                 }
-                
-                
-                if ((ch->pcdata->learned[gsn_form_fly] > 10) || (ch->pcdata->learned[gsn_fly])) 
+
+                if ((ch->pcdata->learned[gsn_form_fly] > 10) || (ch->pcdata->learned[gsn_fly]))
                 {
                         affect_strip(ch, gsn_fly);
                         affect_strip(ch, gsn_levitation);
                         REMOVE_BIT(ch->affected_by, AFF_FLYING);
 
                         send_to_char("Your new form enables you to fly.\n\r", ch);
-                        
+
                         af.type      = gsn_form_fly;
                         af.duration  = -1;
                         af.location  = APPLY_NONE;
@@ -1879,7 +1878,7 @@ void do_morph_fly (CHAR_DATA *ch, bool to_form)
                         affect_to_char(ch, &af);
                 }
         }
-        else 
+        else
         {
                 affect_strip(ch, gsn_form_fly);
                 REMOVE_BIT(ch->affected_by, AFF_FLYING);
@@ -1891,7 +1890,7 @@ void do_morph_fly (CHAR_DATA *ch, bool to_form)
 void do_morph_demon (CHAR_DATA *ch, bool to_form)
 {
         AFFECT_DATA af;
- 
+
         if (to_form)
         {
                 if (ch->pcdata->learned[gsn_form_demon] > 10 || ch->pcdata->learned[gsn_fly])
@@ -1901,7 +1900,7 @@ void do_morph_demon (CHAR_DATA *ch, bool to_form)
                         REMOVE_BIT(ch->affected_by, AFF_FLYING);
 
                         send_to_char("Your new form enables you to fly.\n\r", ch);
-                        
+
                         af.type      = gsn_fly;
                         af.duration  = -1;
                         af.location  = APPLY_NONE;
@@ -1919,14 +1918,14 @@ void do_morph_demon (CHAR_DATA *ch, bool to_form)
 }
 
 
-void do_morph_griffin (CHAR_DATA *ch, bool to_form) 
+void do_morph_griffin (CHAR_DATA *ch, bool to_form)
 {
         AFFECT_DATA af;
         OBJ_DATA *claw;
         OBJ_DATA *claws;
         AFFECT_DATA *paf;
-        
-        if (to_form) 
+
+        if (to_form)
         {
                 if (ch->pcdata->learned[gsn_form_fly] > 10 || ch->pcdata->learned[gsn_fly])
                 {
@@ -1935,7 +1934,7 @@ void do_morph_griffin (CHAR_DATA *ch, bool to_form)
                         REMOVE_BIT(ch->affected_by, AFF_FLYING);
 
                         send_to_char("Your new form enables you to fly.\n\r", ch);
-                        
+
                         af.type      = gsn_fly;
                         af.duration  = -1;
                         af.location  = APPLY_NONE;
@@ -1943,18 +1942,18 @@ void do_morph_griffin (CHAR_DATA *ch, bool to_form)
                         af.bitvector = AFF_FLYING;
                         affect_to_char(ch, &af);
                 }
- 
+
                 claws = create_object(get_obj_index(OBJ_TIGER_CLAWS), ch->level);
                 claw = create_object(get_obj_index(OBJ_TIGER_CLAWS), ch->level);
- 
-                if (!affect_free) 
+
+                if (!affect_free)
                         paf = alloc_perm(sizeof(*paf));
                 else
                 {
                         paf = affect_free;
                         affect_free = affect_free->next;
                 }
-                
+
                 paf->type = gsn_morph;
                 paf->duration = -1;
                 paf->location = APPLY_HITROLL;
@@ -1962,15 +1961,15 @@ void do_morph_griffin (CHAR_DATA *ch, bool to_form)
                 paf->bitvector = 0;
                 paf->next = claws->affected;
                 claws->affected = paf;
-                
-                if (!affect_free) 
+
+                if (!affect_free)
                         paf = alloc_perm(sizeof(*paf));
                 else
                 {
                         paf = affect_free;
                         affect_free = affect_free->next;
                 }
-                
+
                 paf->type = gsn_morph;
                 paf->duration = -1;
                 paf->location = APPLY_DAMROLL;
@@ -1978,18 +1977,18 @@ void do_morph_griffin (CHAR_DATA *ch, bool to_form)
                 paf->bitvector = 0;
                 paf->next = claws->affected;
                 claws->affected = paf;
-                
+
                 obj_to_char(claws, ch);
                 form_equip_char(ch, claws, WEAR_DUAL);
-                
-                if (!affect_free) 
+
+                if (!affect_free)
                         paf = alloc_perm(sizeof(*paf));
-                else 
+                else
                 {
                         paf = affect_free;
                         affect_free = affect_free->next;
                 }
- 
+
                 paf->type = gsn_morph;
                 paf->duration = -1;
                 paf->location = APPLY_DAMROLL;
@@ -1997,25 +1996,25 @@ void do_morph_griffin (CHAR_DATA *ch, bool to_form)
                 paf->bitvector = 0;
                 paf->next = claw->affected;
                 claw->affected = paf;
-                
+
                 obj_to_char(claw, ch);
                 form_equip_char(ch, claw, WEAR_WIELD);
         }
         else
         {
-                affect_strip(ch, gsn_fly);   
+                affect_strip(ch, gsn_fly);
                 affect_strip(ch, gsn_levitation);
                 REMOVE_BIT(ch->affected_by, AFF_FLYING);
-                 
+
                 claws = get_obj_wear(ch, "sftclaws");
                 claw = get_obj_wear(ch, "sftclaw");
-                if (claws) 
+                if (claws)
                 {
                         unequip_char(ch, claws);
                         extract_obj(claws);
                 }
 
-                if (claw) 
+                if (claw)
                 {
                         unequip_char(ch, claw);
                         extract_obj(claw);
@@ -2024,7 +2023,7 @@ void do_morph_griffin (CHAR_DATA *ch, bool to_form)
 }
 
 
-void do_morph (CHAR_DATA *ch, char *argument) 
+void do_morph (CHAR_DATA *ch, char *argument)
 {
         int sn;
         int form;
@@ -2032,23 +2031,23 @@ void do_morph (CHAR_DATA *ch, char *argument)
         int old_form;
         char buf[MAX_STRING_LENGTH];
         char buf1[MAX_STRING_LENGTH];
-        
-        if (IS_NPC(ch)) 
+
+        if (IS_NPC(ch))
                 return;
-        
-        if (!CAN_DO(ch, gsn_morph)) 
+
+        if (!CAN_DO(ch, gsn_morph))
         {
                 send_to_char("Huh?  What?\n\r", ch);
                 return;
         }
 
-        if (is_affected(ch, gsn_mist_walk) || is_affected(ch, gsn_astral_sidestep)) 
+        if (is_affected(ch, gsn_mist_walk) || is_affected(ch, gsn_astral_sidestep))
         {
                 send_to_char("You cannot do that in your current form\n\r",ch);
                 return;
         }
-        
-        if (argument[0] == '\0') 
+
+        if (argument[0] == '\0')
         {
                 send_to_char("Morph to which form?\n\r", ch);
                 return;
@@ -2056,19 +2055,19 @@ void do_morph (CHAR_DATA *ch, char *argument)
 
         old_form = ch->form;
         form = extra_form_int(argument);
- 
-        if (form == -1) 
+
+        if (form == -1)
         {
                 send_to_char("Which form was that?\n\r", ch);
                 return;
         }
-        
-        if( ch->sub_class == SUB_CLASS_VAMPIRE && form != FORM_NORMAL ) 
+
+        if( ch->sub_class == SUB_CLASS_VAMPIRE && form != FORM_NORMAL )
         {
                 send_to_char( "You can no longer change your form.\n\r", ch );
                 return;
         }
-        
+
         if (ch->sub_class == SUB_CLASS_WEREWOLF)
         {
                 if (form != FORM_NORMAL && form != FORM_WOLF)
@@ -2076,56 +2075,62 @@ void do_morph (CHAR_DATA *ch, char *argument)
                         send_to_char ("You may only morph between wolf and normal forms.\n\r", ch);
                         return;
                 }
-                
+
                 if (IS_FULL_MOON && form == FORM_NORMAL)
                 {
                         send_to_char("Not while the moon is full!\n\r", ch);
                         return;
                 }
         }
-        
-        if (form == ch->form) 
+
+        if (form == ch->form)
         {
                 send_to_char("You are already in that form.\n\r", ch);
                 return;
         }
-        
+
         strcpy(buf, extra_form_name(form));
         strcat(buf, " form");
-        
+
         sn = skill_lookup(buf);
-  
-        if ((sn == -1) && (form != 0)) 
+
+        if ((sn == -1) && (form != 0))
         {
                 send_to_char("That form is not possible.\n\r", ch);
                 return;
         }
-        
-        if ((ch->pcdata->learned[sn] < 20) && (form != 0)) 
+
+        if ((ch->pcdata->learned[sn] < 20) && (form != 0))
         {
                 send_to_char("You don't know that form well enough to morph into it.\n\r", ch);
                 return;
         }
-  
-        if (form != FORM_NORMAL) 
+
+        if (form != FORM_NORMAL)
                 cost =  UMAX (skill_table[sn].min_mana, 60 - ch->pcdata->learned[sn]);
-        else 
+        else
                 cost = 10;
 
-        if (ch->mana - cost < 0) 
+        if (ch->mana - cost < 0)
         {
                 send_to_char("You do not have enough mana.\n\r",ch);
                 return;
         }
-        
+
         if (form == FORM_FLY)
         {
+                if (ch->pcdata->group_leader == ch)
+                {
+                        send_to_char("You can't lead a group in a non-corporeal form.\n\r", ch);
+                        return;
+                }
+
                 if (ch->fighting)
                 {
                         send_to_char("You may not morph into a fly while fighting.\n\r", ch);
                         return;
                 }
-                
+
                 if (is_entered_in_tournament(ch)
                     && tournament_status == TOURNAMENT_STATUS_RUNNING
                     && is_still_alive_in_tournament(ch))
@@ -2134,72 +2139,72 @@ void do_morph (CHAR_DATA *ch, char *argument)
                         return;
                 }
         }
-                
-        ch->mana -= cost; 
-        WAIT_STATE(ch, skill_table[gsn_morph].beats); 
-        
-        if (form == FORM_WOLF 
-            && !IS_NPC(ch) 
+
+        ch->mana -= cost;
+        WAIT_STATE(ch, skill_table[gsn_morph].beats);
+
+        if (form == FORM_WOLF
+            && !IS_NPC(ch)
             && ch->pcdata->learned[gsn_form_wolf] > 95
             && ch->level > 59)
         {
                 form = FORM_DIREWOLF;
         }
-        
+
         /* Fix Shade - did in prod direct might not work */
         ch->form = form;
-        
+
         form_equipment_update(ch);
-        
-        sprintf(buf, "\n\rYou morph from %s", extra_form_name(old_form));       
+
+        sprintf(buf, "\n\rYou morph from %s", extra_form_name(old_form));
         sprintf(buf1, " to %s form.\n\r", extra_form_name(form));
         strcat(buf, buf1);
-        
+
         send_to_char(buf, ch);
-        
+
         if (form != FORM_NORMAL)
         {
                 sprintf(buf, "$n shimmers and morphs into a %s.\n\r",
                         extra_form_name(form));
                 act (buf, ch, NULL, NULL, TO_ROOM);
         }
-        else 
+        else
                 act ("$n shimmers and returns to normal.\n\r", ch, NULL, NULL, TO_ROOM);
-        
-        switch (old_form) 
+
+        switch (old_form)
         {
-            case FORM_CHAMELEON: 
+            case FORM_CHAMELEON:
                 do_morph_chameleon(ch, FALSE);
                 break;
-                
+
             case FORM_HAWK:
                 do_morph_hawk(ch, FALSE);
                 break;
-                
+
             case FORM_CAT:
                 do_morph_cat(ch, FALSE);
                 break;
-                
+
             case FORM_SNAKE:
                 do_morph_snake(ch, FALSE);
                 break;
-                
+
             case FORM_SCORPION:
                 do_morph_scorpion(ch, FALSE);
                 break;
-                
+
             case FORM_SPIDER:
                 do_morph_spider(ch, FALSE);
                 break;
-                
+
             case FORM_BEAR:
                 do_morph_bear(ch, FALSE);
                 break;
-                
+
             case FORM_TIGER:
                 do_morph_tiger(ch, FALSE);
                 break;
-                
+
             case FORM_WOLF:
                 do_morph_wolf(ch, FALSE);
                 break;
@@ -2211,94 +2216,94 @@ void do_morph (CHAR_DATA *ch, char *argument)
             case FORM_HYDRA:
                 do_morph_hydra(ch, FALSE);
                 break;
-                
-            case FORM_DRAGON: 
+
+            case FORM_DRAGON:
                 do_morph_dragon(ch, FALSE);
                 break;
-                
-            case FORM_PHOENIX: 
+
+            case FORM_PHOENIX:
                 do_morph_phoenix(ch, FALSE);
                 break;
-                
-            case FORM_FLY:  
+
+            case FORM_FLY:
                 do_morph_fly(ch, FALSE);
                 break;
-                
+
             case FORM_GRIFFIN:
                 do_morph_griffin(ch, FALSE);
                 break;
-                
+
             case FORM_DEMON:
                 do_morph_demon(ch, FALSE);
                 break;
         }
-        
-        switch (form) 
+
+        switch (form)
         {
-            case FORM_CHAMELEON: 
+            case FORM_CHAMELEON:
                 do_morph_chameleon(ch, TRUE);
                 break;
-                
+
             case FORM_HAWK:
                 do_morph_hawk(ch, TRUE);
                 break;
-                
+
             case FORM_CAT:
                 do_morph_cat(ch, TRUE);
                 break;
-                
+
             case FORM_SNAKE:
                 do_morph_snake(ch, TRUE);
                 break;
-                
+
             case FORM_SCORPION:
                 do_morph_scorpion(ch, TRUE);
                 break;
-                
+
             case FORM_SPIDER:
                 do_morph_spider(ch, TRUE);
                 break;
-                
+
             case FORM_BEAR:
                 do_morph_bear(ch, TRUE);
                 break;
-                
+
             case FORM_TIGER:
                 do_morph_tiger(ch, TRUE);
                 break;
-                
-            case FORM_WOLF:       
+
+            case FORM_WOLF:
                 do_morph_wolf(ch, TRUE);
                 break;
-                
+
             case FORM_DIREWOLF:
                 do_morph_direwolf(ch, TRUE);
                 break;
-                
+
             case FORM_HYDRA:
                 do_morph_hydra(ch, TRUE);
                 break;
-                
-            case FORM_DRAGON:   
+
+            case FORM_DRAGON:
                 do_morph_dragon(ch, TRUE);
                 break;
-                
+
             case FORM_PHOENIX:
                 do_morph_phoenix(ch, TRUE);
                 break;
-                
+
             case FORM_FLY:
                 do_morph_fly(ch, TRUE);
                 break;
-                
+
             case FORM_GRIFFIN:
                 do_morph_griffin(ch, TRUE);
                 break;
-                
+
             case FORM_DEMON:
                 do_morph_demon(ch, TRUE);
                 break;
-                
+
         }
 }
 

--- a/server/src/update.c
+++ b/server/src/update.c
@@ -1853,22 +1853,27 @@ void aggr_update()
                         {
                                 if (IS_NPC(vch)
                                     || vch->deleted
+                                    || IS_AFFECTED(vch, AFF_NON_CORPOREAL)
                                     || vch->level >= LEVEL_IMMORTAL)
                                         continue;
 
-                                if ((!IS_SET(mch->act, ACT_WIMPY) || !IS_AWAKE(vch))
-                                    && can_see(mch, vch))
+                                if ( ( !IS_SET( mch->act, ACT_WIMPY )
+                                    || !IS_AWAKE( vch ) )
+                                    && can_see( mch, vch ) )
                                 {
-                                        if (!number_range(0, count))
+                                        if ( !number_range( 0, count ) )
                                         {
-                                                if (vch->pcdata->group_leader
-                                                    && can_see(mch, vch->pcdata->group_leader)
-                                                    && vch->pcdata->group_leader->in_room == mch->in_room)
+                                                if ( vch->pcdata->group_leader == vch
+                                                &&   !(IS_AFFECTED(vch->pcdata->group_leader, AFF_NON_CORPOREAL))
+                                                &&   can_see(mch, vch->pcdata->group_leader)
+                                                &&   vch->pcdata->group_leader->in_room == mch->in_room)
                                                 {
                                                         victim = vch->pcdata->group_leader;
                                                 }
                                                 else
+                                                {
                                                         victim = vch;
+                                                }
                                         }
                                         count++;
                                 }
@@ -2212,7 +2217,7 @@ void add_morph_list(CHAR_DATA *ch, int iWear)
 
         unequip_char(ch, theObj);
         ch->pcdata->morph_list[iWear] = theObj;
-        
+
 }
 
 
@@ -2268,7 +2273,7 @@ void form_equipment_update (CHAR_DATA *ch)
 
                         else if (!form_wear_table[ch->form].can_wear[jter])
                                 add_morph_list(ch, iter);
-                                
+
                 }
         }
 }


### PR DESCRIPTION
Issue is having noncorp (mist walk, astral sidestep, fly form) shifters leading groups and their forms failing to protect them from being aggroed, or from being targeted if their groupmates flee or die. Ideally they shouldn't be partaking in combat at ALL when in those forms (or gaining xp, doing damage, etc).

This partial fix:
-prevents a noncorp from being made leader of a group
-prevents a shifter changing to a noncorp form if leading a group
-prevents a noncorp group leader (which yes, shouldn't be able to happen due to above) being aggroed

It will not:
-Prevent them from being attacked if the leader dies or flees
-Stop them getting XP
-Stop them fighting generally in a group battle (I don't think?)

Ideally we should either:
- Have noncorps be uninvolved in group combat while noncorped (no damage given or taken, no xp)
- Not allow noncorps to group, and either kick them out or stop them noncorping while in groups.

