### PR TITLE
Minor vamp fixes

### DIFF
--- a/server/area/helpfile.are
+++ b/server/area/helpfile.are
@@ -257,6 +257,8 @@ See 'HELP SUBCLASSES' for more information on subclasses.
 - Crating and Spellcrafting items have been added
 - Total XP message added
 - Thief skill 'smoke bomb' added
+- Vampires and Werewolfs will gain bonus pracs at 30
+- Lunge and suck damage modified by current blood status
 
 {WApril 2022{x
 
@@ -4581,9 +4583,10 @@ it will let the player concentrate on the enemy that is most dangerous.
 0 SUCK~
 Syntax: suck <target>
 
-This Vampire skill attempts to suck the blood from a victim.  A successful
-attack will cause damage to the victim, while increasing the blood points
-of the Vampire.
+This Vampire skill attempts to suck the blood from a victim.  A Vampire who
+is full with blood will have a stronger suck than one craving blood. 
+A successful attack will cause damage to the victim, while also increasing 
+the blood points of the Vampire.
 ~
 
 0 FEED~
@@ -5473,9 +5476,11 @@ Using this spell a caster drains the life force of their enemy.
 0 LUNGE 'DOUBLE LUNGE'~
 Syntax: lunge <target>
 
-A bloodthirsty VAMPIRE may lunge for an opponent's neck, causing heavy
+A bloodthirsty Vampire may lunge for an opponent's neck, causing heavy
 damage.  Lunge can only be used on an unprepared enemy.  DOUBLE LUNGE is
-even more devastating.
+even more devastating.  Vampires full on blood will have a more powerful
+lunge, Vampires weak on blood will have a weaker lunge.
+
 ~
 
 0 'RIDING TECHNIQUES'~

--- a/server/area/pirates.are
+++ b/server/area/pirates.are
@@ -437,6 +437,7 @@ ShapeShifter. You might be able to learn from this master.
 & 85 'lycanthropy skills'
 & 85 'vampyre skills'
 & 85 'inner force'
+& 85 'armed combat knowledge'
 #17044
 terra-kan bird terra kan~
 the terra-kan~

--- a/server/src/act_info.c
+++ b/server/src/act_info.c
@@ -560,8 +560,13 @@ void show_char_to_char (CHAR_DATA *list, CHAR_DATA *ch)
                 if (can_see(ch, rch))
                         show_char_to_char_0(rch, ch);
 
+                /*
+                 * Shade - 10.5.22 - Vampires shouldn't see hidden mobs in teh dark
+                 */
+
                 else if (room_is_dark(ch->in_room)
                          && IS_AFFECTED(rch, AFF_INFRARED)
+                         && ch->sub_class != SUB_CLASS_VAMPIRE
                          && (!IS_NPC(rch) || !IS_SET(rch->act, ACT_WIZINVIS_MOB)))
                         send_to_char("You see glowing red eyes watching YOU!\n\r", ch);
         }

--- a/server/src/act_move.c
+++ b/server/src/act_move.c
@@ -2362,13 +2362,20 @@ void do_change (CHAR_DATA *ch, char *argument)
 
         /* do the change */
 
-        sprintf(buf, "A wise choice %s... may you fare well as a %s.",
-                ch->name, full_sub_class_name(ch->sub_class));
+        sprintf(buf, "A wise choice %s... may you fare well as a %s.", ch->name, full_sub_class_name(ch->sub_class));
         do_say(mob, buf);
 
         ch->pcdata->choose_subclass = TRUE;
         ch->pcdata->learned[gsn_ranger_base + ch->sub_class ] = 30;
 
+        if (ch->sub_class == SUB_CLASS_VAMPIRE || ch->sub_class == SUB_CLASS_WEREWOLF)
+        {
+                sprintf(buf, "%ss are a challenging class %s, I shall grant you some additional practices to help.", full_sub_class_name(ch->sub_class), ch->name);
+                do_say(mob, buf);
+
+                ch->pcdata->int_prac += 5;
+                ch->pcdata->str_prac += 5;
+        }
 
         /* remove any eq the new class can't wear; Gezhp */
 

--- a/server/src/const.c
+++ b/server/src/const.c
@@ -4103,7 +4103,7 @@ const struct skill_type skill_table [MAX_SKILL] =
         },
 
         {
-                "Vampyre skills", &gsn_group_vampyre,
+                "vampyre skills", &gsn_group_vampyre,
                 TYPE_INT, TAR_IGNORE, POS_DEAD,
                 spell_null, 0, 0,
                 "", "!Group Vampyre!"

--- a/server/src/fight.c
+++ b/server/src/fight.c
@@ -661,8 +661,19 @@ bool one_hit (CHAR_DATA *ch, CHAR_DATA *victim, int dt)
                         else if (dt == gsn_joust || dt == gsn_dive )
                                 dam *= 2 + (ch->level / 20);
 
-                        else if (dt == gsn_lunge)
+                        else if (dt == gsn_lunge) 
+                        {
                                 dam += dam / 2;
+
+                                /*
+                                 * Shade 10.5.22 - make high / low blood have an impact
+                                 */
+
+                                if (ch->rage > (ch->max_rage * 3 / 4))
+                                        dam += dam / 10;
+                                else if (ch->rage < ch->max_rage / 4)
+                                        dam -= dam / 10;                                                
+                        }
 
                         else if (dt == gsn_shoot)
                         {
@@ -670,8 +681,22 @@ bool one_hit (CHAR_DATA *ch, CHAR_DATA *victim, int dt)
                                 dam += dam * ch->pcdata->learned[gsn_accuracy] / 300;
                         }
 
-                        else if (dt == gsn_circle || dt == gsn_constrict || dt == gsn_suck || dt == gsn_thrust)
+                        else if (dt == gsn_circle || dt == gsn_constrict || dt == gsn_thrust)
                                 dam += dam / 2;
+
+                        else if (dt == gsn_suck)
+                        {
+                                dam += dam / 2;
+
+                                /*
+                                 * Shade 10.5.22 - make high / low blood have an impact
+                                 */
+
+                                if (ch->rage > (ch->max_rage * 3 / 4))
+                                        dam += dam / 10;
+                                else if (ch->rage < ch->max_rage / 4)
+                                        dam -= dam / 10;                                                
+                        }
 
                         else if (dt == gsn_second_circle)
                                 dam *= 2;
@@ -1872,7 +1897,7 @@ void set_fighting (CHAR_DATA *ch, CHAR_DATA *victim)
 
         if (!IS_NPC(ch)
             && ch->sub_class == SUB_CLASS_WEREWOLF
-            && (ch->rage > 85 || IS_FULL_MOON)
+            && (ch->rage > 80 || IS_FULL_MOON)
             && !is_affected(ch, gsn_berserk))
         {
                 AFFECT_DATA af;
@@ -3428,7 +3453,7 @@ void do_lunge (CHAR_DATA *ch, char *argument)
 
         if (!IS_NPC(ch) && !CAN_DO(ch, gsn_lunge))
         {
-                send_to_char("Thou are not a Vampyre.\n\r", ch);
+                send_to_char("Thou are not a Vampire.\n\r", ch);
                 return;
         }
 

--- a/server/src/pre_reqs/pre_req-vampire.c
+++ b/server/src/pre_reqs/pre_req-vampire.c
@@ -23,7 +23,7 @@
 
 { &gsn_transfix,                &gsn_group_vampyre,             30,     PRE_VAMPIRE},
 
-{ &gsn_suck,                    &gsn_group_vampyre,             50,     PRE_VAMPIRE},
+{ &gsn_suck,                    &gsn_group_vampyre,             30,     PRE_VAMPIRE},
 
 { &gsn_lunge,                   &gsn_suck,                      70,     PRE_VAMPIRE},
 { &gsn_lunge,                   &gsn_group_vampyre,             70,     PRE_VAMPIRE},
@@ -40,7 +40,8 @@
 { &gsn_deter,                   &gsn_vampire_base,              35,     PRE_VAMPIRE},
 
 {&gsn_group_armed,              &gsn_vampire_base,      30,     PRE_VAMPIRE},
-{&gsn_second_attack,            &gsn_group_armed,       50,     PRE_VAMPIRE},
+{&gsn_second_attack,            &gsn_group_armed,       20,     PRE_VAMPIRE},
+
 {&gsn_enhanced_hit,             &gsn_group_armed,       95,     PRE_VAMPIRE},
 {&gsn_enhanced_hit,             &gsn_vampire_base,      30,     PRE_VAMPIRE},
 

--- a/server/src/skill.c
+++ b/server/src/skill.c
@@ -1432,6 +1432,10 @@ void do_feed (CHAR_DATA *ch, char *argument)
 
         send_to_char("You feed on the fresh corpse!\n\r", ch);
         ch->rage = UMIN(ch->rage +5, ch->max_rage);
+
+        if (ch->rage > (ch->max_rage * 3 / 4))
+                send_to_char("You feel the power of {Rblood{x surge through your fangs!\n\r", ch);
+
         update_pos(ch);
         act ("$n feeds on $p.", ch, corpse, NULL, TO_ROOM);
         extract_obj(corpse);
@@ -1573,6 +1577,10 @@ void do_suck (CHAR_DATA *ch, char *argument)
                 one_hit(ch, victim, gsn_suck);
                 ch->rage += 2;
                 ch->rage = UMIN(ch->rage, ch->max_rage);
+
+                if (ch->rage > (ch->max_rage * 3 / 4))
+                        send_to_char("You feel the power of {Rblood{x surge through your fangs!\n\r", ch);
+
         }
         else
         {

--- a/server/src/update.c
+++ b/server/src/update.c
@@ -918,8 +918,11 @@ int rage_gain( CHAR_DATA *ch )
 
         if (ch->sub_class == SUB_CLASS_VAMPIRE)
         {
+
                 if (ch->rage < ch->max_rage / 10)
-                        send_to_char( "You feel weak - You crave {Rblood!{x\n\r", ch);
+                        send_to_char( "You feel weak - you crave {Rblood!{x\n\r", ch);
+                else if (ch->rage < ch->max_rage / 4)
+                        send_to_char(" You feel weakened - the power of your {Rlunge{x is reduced!\n\r", ch);
 
                 if (!ch->pcdata->condition[COND_THIRST] && ch->level < LEVEL_HERO)
                         gain *= 2;


### PR DESCRIPTION
Additional practices at level 30 for vampires and werewolves

Initial vampire pre-reqs made easier so in theory, a level 30 vampire should immediately be able to get second attack, transfix and suck and then lunge at level 31 meaning just one potentially painful level

Lunge/suck impacted by current blood level (+/ 10%)

Fixed issue with vampires seeing glowings eyes in the dark when a mob is hidden

Added armed combat knowledge to Hawklord