### PR TITLE
Crafting objects are in.

### DIFF
--- a/server/area/bastion.are
+++ b/server/area/bastion.are
@@ -1425,6 +1425,14 @@ A dust-covered vial of clear liquid is here.~
 10 16|64 1
 100~ power heal~ remove curse~ energy containment~
 1 0 0
+#30662
+forge~
+a forge~
+A large forge dominates the room.~
+~
+40 1 0
+15~ 0~ 0~ 0~
+1000 0 0
 #0
 
 #ROOMS
@@ -5833,6 +5841,7 @@ S
 
 
 #RESETS
+O 1 30662 100 30803         forge to The workshop
 *
 M 1 30600 5 30624           the Stone Gargoyle to Before the gate
 E 1 30600 100 12

--- a/server/area/citie.are
+++ b/server/area/citie.are
@@ -1,4 +1,4 @@
-#AREA    Sneak~    City Of Thieves ~
+#AREA    Sneak~    City Of Thieves~
 30 50 0 100
 
 #MOBILES
@@ -7,7 +7,7 @@ spirit stalker~
 the Spirit Stalker~
 A spirit stalker stands here.
 ~
-This asassin looks like he could kill death itself.
+This assassin looks like he could kill death itself.
 ~
 2|32|64 65536 -500 S
 48 0 0 0d0+0 0d0+0
@@ -18,7 +18,7 @@ moon dog~
 a moon dog~
 A moondog stands here ready to pounce.
 ~
-A strange glow eminates from the dogs coat.
+A strange glow emanates from the dogs coat.
 ~
 2|64 0 -500 S
 40 0 0 0d0+0 0d0+0
@@ -1364,6 +1364,14 @@ A copper key lies here~
 18 0 1|16384
 0~ 0~ 0~ 0~
 5 0 0
+#23588
+forge~
+a forge~
+A large forge dominates the room.~
+~
+40 1 0
+10~ 0~ 0~ 0~
+1000 0 0
 #0
 
 
@@ -3268,6 +3276,7 @@ S
 
 
 #RESETS
+O 1 23588 100 23586     ; forge to A Stable
 D 1 23595 0 2           ; A Dark Tower Lock North
 D 1 23596 2 2           ; Tower Hallway. Lock South
 D 1 23598 2 1           ; 1st Floor Room. Close South

--- a/server/area/cyclops.are
+++ b/server/area/cyclops.are
@@ -1347,6 +1347,14 @@ A
 18 15
 A
 19 5
+#14079
+forge~
+a forge~
+A large forge dominates the room.~
+~
+40 1 0
+15~ 0~ 0~ 0~
+1000 0 0
 #0
 
 
@@ -3778,6 +3786,7 @@ S
 
 
 #RESETS
+O 1 14079 100 14053         ; A forge to The smithy's cave
 D 1 14101 3 1               ; The pantry Close West
 D 1 14100 1 1               ; The kitchen Close East
 D 1 14102 2 1               ; The steam room Close South

--- a/server/area/deserts.are
+++ b/server/area/deserts.are
@@ -614,6 +614,14 @@ A small key half hidden, lies here.~
 18 128 1|16384
 0~ 1~ 6~ 11~
 1 0 0
+#13635
+bench workbench~
+a spellcrafting bench~
+A workbench for magical crafting stands here.~
+~
+41 64 0
+15~ 0~ 0~ 0~
+1000 0 0
 #0
 
 
@@ -1543,6 +1551,7 @@ S
 
 
 #RESETS
+O 1 13635 100 13639
 D 1 13615 4 1           ; The hidden tunnel Close Up
 D 1 13614 5 2           ; The Clearing Lock Down
 D 1 13616 4 1           ; The tomb Close Up

--- a/server/area/dungeons.are
+++ b/server/area/dungeons.are
@@ -1355,6 +1355,14 @@ E
 stone archwizard~
 The magical stone of the Arch-Wizard floats above the ground, glowing and radiating
 peaceful and harmonious energy.~
+#13378
+bench workbench~
+a spellcrafting bench~
+A workbench for magical crafting stands here.~
+~
+41 64 0
+15~ 0~ 0~ 0~
+1000 0 0
 #0
 
 
@@ -3666,6 +3674,7 @@ S
 
 
 #RESETS
+O 1 13378 100 13407
 D 1 13306 2 1                   ; A room Close South
 D 1 13305 0 1                   ; The Stairway Close North
 *

--- a/server/area/foundry.are
+++ b/server/area/foundry.are
@@ -294,6 +294,22 @@ Beautifully iridescent blue snakeskin has been used to fashion these
 boots, which are comfortably lined with soft leather and reach just
 above your ankles.
 ~
+#111
+Crafting test object~
+a crafting test object~
+A crafting test object sits here.~
+~
+40 0 0
+25~ 0~ 0~ 0~
+15 0 0
+#112
+Spellcrafting test object~
+a spellcrafting test object~
+A crafting test object sits here.~
+~
+41 0 0
+25~ 0~ 0~ 0~
+15 0 0
 #0
 
 

--- a/server/area/freeport.are
+++ b/server/area/freeport.are
@@ -867,6 +867,14 @@ A prism shimmers on the ground here.~
 3 32|64 1|16384
 50~ 30~ 30~ invis~
 1 0 0
+#29135
+forge~
+a forge~
+A large forge dominates the room.~
+~
+40 1 0
+10~ 0~ 0~ 0~
+1000 0 0
 #0
 
 
@@ -2368,6 +2376,7 @@ S
 
 
 #RESETS
+O 1 29135 100 29151
 M 1 29101 2 29140           Blue Lizard
 G 1 29102 0    tongue
 M 1 29102 2 29130           Red Lizard

--- a/server/area/helpfile.are
+++ b/server/area/helpfile.are
@@ -702,6 +702,8 @@ Certain physical skills and magic spells can have the power
 of their effects improved by being performed or cast in locations
 that are equipped to assist them.  Such locations will reveal
 themselves to those who have the relevant skills or spells.
+Additionally, certain objects may further improve your crafting
+abilities if present in such locations.
 
 Current physical skills that benefit from crafting locations:
 
@@ -2195,6 +2197,49 @@ WHERE with an argument tells you the location of all creatures with that
 name within your area.
 ~
 
+101 CRAFTLOC~
+Crafting and spellcrafting locations:
+
+{CCRAFTING{x
+--------
+{WVNUM    ROOM                        AREA                        LEVEL       FILENAME{x
+29966   [The lemming smithy]        [The Lemming Caves]         [5 15]      [lemmings2.are]
+2503    [The Armourer]              [Ultima]                    [5 30]      [ultima.are] {R*{x
+5321    [The smithy]                [Old Thalos]                [10 25]     [mirror.are] {R*{x
+5221    [The smithy]                [Thalos]                    [10 25]     [thalos.are]
+1381    [A very hot room]           [Tower of Sorcery]          [10 30]     [hitower.are]
+937     [Smithy]                    [Olympus]                   [20 35]     [olympus.are]
+29868   [The smithy]                [Prince's Fortress]         [20 40]     [usurper.are]
+23586   [A Stable.]                 [City Of Thieves]           [30 50]     [citie.are] {R*{x
+14053   [The smithy's cave]         [Cyclops Caves]             [35 55]     [cyclops.are] {R*{x
+31254   [Base of Southwest Tower]   [The Walls of Anon]         [45 60]     [tcwn2.are]
+4752    [Blacksmith's Home]         [Kingdom of Juargan]        [45 65]     [juargan.are] {R*{x
+24023   [The Cobresh Smithy.]       [The Yitrite Mines]         [50 75]     [yitrite.are] {R*{x
+30021   [Gryphon Smithy]            [Krondor]                   [0 100]     [krondor.are]
+28096   [Jasmir's Armory]           [Draagdim]                  [0 100]     [draagdim.are]
+29151   [The Bronze Scabbard]       [Freeport]                  [0 100]     [freeport.are] {R*{x
+30803   [The workshop]              [Bastion of Shadows]        [80 100]    [bastion.are] {R*{x
+5321    [The smithy]                [Old Thalos]                [10 25]     [mirror.are] {R*{x
+603     [The Blacksmith]            [New Ofcol]                 [0 100]     [ofcol2.are]
+31041   [The Smithy]                [The City of Anon]          [0 100]     [tcwn.are]
+
+{MSPELLCRAFTING{x
+-------------
+3019    [Mage's Laboratory]         [Midgaard]                  [0 100]     [midgaard.are]
+9419    [The Laboratory]            [Fleshmonger's Tower]       [5 15]      [fleshmonger.are]
+1386    [A laboratory]              [Tower of Sorcery]          [10 30]     [hitower.are]
+16437   [Experimentation Room]      [Underdark]                 [20 60]     [under2.are] {R*{x
+9533    [Velkyn's laboratory]       [Vampire Catacombs]         [25 35]     [vampcat.are] {R*{x
+10148   [A Laboratory]              [Witch's Tower]             [25 35]     [witch.are] {R*{x
+25107   [Transformation Laboratory] [Kahsis]                    [35 60]     [kahsis.are] {R*{x
+20387   [The Laboratory]            [The Fortress of Goblins]   [40 60]     [fortress.are]
+13639   [A small laboratory]        [The Valley of Dreams]      [45 60]     [deserts.are] {R*{x
+13407   [The Laboratory]            [The Catacombs]             [0 100]     [dungeons.are] {R*{x
+15782-15786  [Various]              [Mount Doom]                [60 85]     [mtdoom2.are]
+14644   [The Laboratory]            [Zyklor's Tower]            [60 100]    [tower.are] {R*{x
+
+{R*{x Contain crafting bonus objects
+~
 
 104 TRUST~
 Syntax: trust <character> <level>

--- a/server/area/juargan.are
+++ b/server/area/juargan.are
@@ -207,6 +207,14 @@ A large and intricate staff rests here.~
 4 2 16385
 50~ 10~ 10~ charm person~
 10 10000 100
+#4709
+forge~
+a forge~
+A large forge dominates the room.~
+~
+40 1 0
+10~ 0~ 0~ 0~
+1000 0 0
 #0
 
 
@@ -1458,6 +1466,7 @@ S
 
 
 #RESETS
+O 1 4709 100 4752       ; forge to a Blacksmith's Home
 M 0 4700 10 4705           *A couple of miners.
 E 1 4701 100 16
 M 0 4700 10 4709

--- a/server/area/kahsis.are
+++ b/server/area/kahsis.are
@@ -1501,6 +1501,14 @@ E
 egg crocodile~
 The large spherical egg is soft and moist, carrying a faint odour.
 ~
+#25069
+bench workbench~
+a spellcrafting bench~
+A workbench for magical crafting stands here.~
+~
+41 64 0
+15~ 0~ 0~ 0~
+1000 0 0
 #0
 
 
@@ -4229,6 +4237,7 @@ S
 
 
 #RESETS
+O 1 25069 100 25107             ; a magical workbench to Transformation Lab
 D 1 25011 0 2                   ; The Seal Lock North
 D 1 25011 1 1                   ; The Seal Close East
 D 1 25011 2 1                   ; The Seal Close South

--- a/server/area/mirror.are
+++ b/server/area/mirror.are
@@ -785,6 +785,14 @@ A
 24 -2
 A
 17 -2
+#5332
+forge~
+a forge~
+A large forge dominates the room.~
+~
+40 1 0
+10~ 0~ 0~ 0~
+1000 0 0
 #0
 
 
@@ -2650,6 +2658,7 @@ S
 
 
 #RESETS
+O 1 5332 100 5321       forge to The smithy
 M 0 5306 1 5319         Fanatic Priest
 E 1 5218 8  3           (talisman)
 E 1 5222 8 12           (black robe)

--- a/server/area/mtdoom2.are
+++ b/server/area/mtdoom2.are
@@ -3079,7 +3079,7 @@ The Quarters of the Archmage~
 You have barged into the quarters of Axtraxes, arch mage of Krothgar, and
 ruined his experiment. He's BOUND to be upset.
 ~
-0 8 0
+0 8|256 0
 D0
 ~
 ~
@@ -3092,7 +3092,7 @@ alembics and a hundred other items scattered about on desks, benches, chairs
 and floors. Everything appears rather damaged, as if someone (or something)
 has recently gone berserk in here...
 ~
-0 8 0
+0 8|256 0
 D0
 ~
 ~
@@ -3117,7 +3117,7 @@ alembics and a hundred other items scattered about on desks, benches, chairs
 and floors. Everything appears rather damaged, as if someone (or something)
 has recently gone berserk in here...
 ~
-0 8 0
+0 8|256 0
 D1
 ~
 ~
@@ -3130,7 +3130,7 @@ alembics and a hundred other items scattered about on desks, benches, chairs
 and floors. Everything appears rather damaged, as if someone (or something)
 has recently gone berserk in here...
 ~
-0 8 0
+0 8|256 0
 D2
 ~
 ~
@@ -3143,7 +3143,7 @@ alembics and a hundred other items scattered about on desks, benches, chairs
 and floors. Everything appears rather damaged, as if someone (or something)
 has recently gone berserk in here...
 ~
-0 8 0
+0 8|256 0
 D3
 ~
 ~

--- a/server/area/tower.are
+++ b/server/area/tower.are
@@ -2119,9 +2119,9 @@ A concentrated mass of energy floats in the middle of the room.~
 A
 19 9
 #14601
-coins horde~
+coins hoard~
 coins~
-A horde of coins lies in he corner of the room.~
+A hoard of coins lies in the corner of the room.~
 ~
 20 0 1
 1208~ 650~ 457~ 221~
@@ -2352,6 +2352,14 @@ A
 18 35
 A
 19 35
+#14625
+bench workbench~
+a spellcrafting bench~
+A workbench for magical crafting stands here.~
+~
+41 64 0
+15~ 0~ 0~ 0~
+1000 0 0
 #0
 
 
@@ -7560,6 +7568,7 @@ S
 
 
 #RESETS
+O 1 14625 100 14644 ; magical workbench to The Laboratory
 D 1 14520 2 2       ; Entrance-way to the Castle Lock South
 D 1 14519 0 2       ; Before the gates. Lock North
 D 1 14521 2 2        ; Entrance to the Castle Lock South

--- a/server/area/ultima.are
+++ b/server/area/ultima.are
@@ -1804,6 +1804,14 @@ hand the feeling evaporates. Truly, this is an artifact of great
 power, and should not be allowed to fall into the wrong hands.
 
 ~
+#2470
+forge~
+a forge~
+A large forge dominates the room.~
+~
+40 1 0
+5~ 0~ 0~ 0~
+1000 0 0
 #0
 
 
@@ -5163,6 +5171,7 @@ S
 #0
 
 #RESETS
+O 1 2470 100 2503 ;forge to the Armourer
 M 0 2400 5 2408 ;load insects on humility street
 M 0 2401 1 2411 ;load a bat in the attic
 G 0 2408 0 ; and have it hold the moonstone

--- a/server/area/under2.are
+++ b/server/area/under2.are
@@ -2887,6 +2887,14 @@ mirror portal~
 The mirror offers a view of the world, constantly changing with such
 complexity that only a god could understand what is being shown.
 It looks almost as if you could step through it...~
+#16096
+bench workbench~
+a spellcrafting bench~
+A workbench for magical crafting stands here.~
+~
+41 64 0
+10~ 0~ 0~ 0~
+1000 0 0
 #0
 
 
@@ -11670,7 +11678,7 @@ twenty feet by twenty.  There are shelves along all the walls and a few
 counters that hold different items of magic.  The shopkeeper stands at the
 far side of the shop behind a counter.
 
-The only way out is north
+The only way out is north.
 ~
 0 1|8|8192 1
 D0
@@ -11687,7 +11695,7 @@ by pins, a few counters provide space for daggers and other assorted small
 arms.  The shopkeeper walks around the shop watching you and is ready to
 buy and sell merchandise.
 
-The sole way out is north
+The sole way out is north.
 ~
 0 1|8|8192 1
 D0
@@ -11702,9 +11710,9 @@ This is the armor shop for the Underdark.  The shop is about thirty feet by
 thirty.  The walls are covered with shields and helms.  There are full suits
 of armor that form rows in the center of the shop.  This is a shop where
 you can get any sort of armor you wish.  The shopkeeper wanders about
-waiting for you to buy something
+waiting for you to buy something.
 
-The sole exit is to the north
+The sole exit is to the north.
 ~
 0 1|8|8192 1
 D0
@@ -11721,7 +11729,7 @@ counter is see through and beneath the barrier lie many different gems and
 stones.  A large wizard eye floats in the air watching you to make sure you
 do not steal anything.
 
-The only exit is north
+The only exit is north.
 ~
 0 1|8|8192 1
 D0
@@ -11736,7 +11744,7 @@ You are standing in a food shop.  This shop is about twenty feet by twenty
 feet.  The shop is dark and the air is musty.  The air smells heavily of
 spice.  There are many counters with all sorts of spices and foods on them.
 
-The sole exit is to the north
+The sole exit is to the north.
 ~
 0 1|8|8192 1
 D0
@@ -11753,7 +11761,7 @@ should they come into trouble here.  The building has a low ceiling, about
 seven feet off the ground.  The walls and ground are earthy in color and
 texture.
 
-The door out is east, and the hallway goes west
+The door out is east, and the hallway goes west.
 ~
 0 1|8|8192 1
 D1
@@ -11776,7 +11784,7 @@ You are standing in the hallway of this building.  The floor in this section
 is a polished stone.  The walls have been carved out of solid rock.  It is
 dark in the hallway and cool.
 
-The entrance is to the east, the hallway continues south
+The entrance is to the east, the hallway continues south.
 ~
 0 1|8|8192 1
 D1
@@ -11797,7 +11805,7 @@ the floor.  The hallway has been carved out of rock and thus the color
 here is gray.  The air is cool and moist, with the sounds of the city a distant
 memory.
 
-The hallway continues north and south, to the east is a door
+The hallway continues north and south, to the east is a door.
 ~
 0 1|8|8192 1
 D0
@@ -11827,7 +11835,7 @@ those who are in need of the help this building offers sleep.  There is a
 simple bed against the far wall and a mirror on the southern wall.  It is
 obvious that people are not meant to stay here long.
 
-The only way out is the door to the west
+The only way out is the door to the west.
 ~
 0 1|8|8192 1
 D3
@@ -11876,7 +11884,7 @@ important guests of the gnome community stay.  The bed looks
 comfortable even if it only five feet long.  The ceiling is a mere six and a
 half feet high here.  There is a large rug that covers the floor.
 
-The sole exit is the door to the west
+The sole exit is the door to the west.
 ~
 0 1|8|8192 1
 D3
@@ -11923,7 +11931,7 @@ the comforts of home, a bed, a desk, and a chest with drawers.  There is a
 chair propped up against the desk.  The ceiling is about six feet off the
 ground.  The room is about fifteen feet by fifteen.
 
-The sole exit is the door to the west
+The sole exit is the door to the west.
 ~
 0 1|8|8192 1
 D3
@@ -11933,7 +11941,7 @@ door~
 1 -1 16367
 E
 door~
-The door is small, wooden and looks to be very strong
+The door is small, wooden and looks to be very strong.
 ~
 S
 #16369
@@ -11943,7 +11951,7 @@ spacious.  There are many statues and other objects that have been stolen
 from the various rich members of the world.  The floor is dark green and
 polished.  The walls are made of white marble.
 
-The hall continues to the south, there are doors east and west
+The hall continues to the south, there are doors east and west.
 ~
 0 8|8192 1
 D0
@@ -11968,7 +11976,7 @@ door~
 1 -1 16371
 E
 exit~
-The exit door is huge and well built.  There is little else to say about it
+The exit door is huge and well built.  There is little else to say about it.
 ~
 E
 door~
@@ -11983,7 +11991,7 @@ room is about fifteen feet by fifteen feet.  The floor is black and the
 walls are gray.  Small rods that are held in little holders along the walls
 light the room.
 
-The sole exit it the door to the west
+The sole exit it the door to the west.
 ~
 0 8|8192 1
 D3
@@ -12003,7 +12011,7 @@ along the walls and a table in the middle.  There are a few chairs around
 the table and on the table is a deck of cards.  The floor is gray and the
 walls are black.  Small rods light the room.
 
-The only exit it the door to the east
+The only exit it the door to the east.
 ~
 0 8|8192 1
 D1
@@ -12054,7 +12062,7 @@ green that has been polished.  The walls are covered in white marble and
 you see little rivulets of gold creating chaotic patterns in the marble.
 Small rods that are being held on the walls light the way.
 
-The hallway continues east and west
+The hallway continues east and west.
 ~
 0 1|8|8192 1
 D1
@@ -12075,7 +12083,7 @@ is a large mural of a thief picking the gate to a palace.  The floor is dark
 green and glints in the light.  Next to the door on the north wall is a
 pedestal with a large glowing hand.
 
-Door lie north and south, the hallway continues east
+Door lie north and south, the hallway continues east.
 ~
 0 8|8192 1
 D0
@@ -12138,7 +12146,7 @@ wall and the other against the western wall.  There is a small round table in
 the center of the room with four chairs around it.  On the table is a deck of
 cards.
 
-The sole exit is the door to the north
+The sole exit is the door to the north.
 ~
 0 8|8192 1
 D0
@@ -12157,7 +12165,7 @@ lock picks, daggers, swords, darts and anything else they would need to rob
 the world blind.  The room is ten feet by ten feet and the walls are covered
 with shelves.  The shelves are lined with these items.
 
-The sole exit is the door to the east
+The sole exit is the door to the east.
 ~
 0 1|8|8192 1
 D1
@@ -12176,7 +12184,7 @@ changed from dark green to dark red.  The walls are pure white and seem
 to create an atmosphere of good and well being.  The walls glitter with
 gold since there are little rivulets of gold that create many chaotic patterns.
 
-The hallway continues north and south, there is a door to the west
+The hallway continues north and south, there is a door to the west.
 ~
 0 8|8192 1
 D0
@@ -12207,7 +12215,7 @@ You also hear the faint melodious sounds of music.  The whole effect of
 the white walls, soft music and incense makes you feel at ease as if you
 were in a holy place of worship.
 
-The hallway heads north, there is a door to the west
+The hallway heads north, there is a door to the west.
 ~
 0 8|8192 1
 D0
@@ -12231,7 +12239,7 @@ contain many different containers, each of the containers is locked with a
 different kind of lock.  The floor is dark red and the walls are dark gray.
 Small rods provide a soft glow that lights everything in the room.
 
-There are doors to the east and west
+There are doors to the east and west.
 ~
 0 8|8192 1
 D1
@@ -14900,6 +14908,7 @@ S
 
 
 #RESETS
+O 1 16096 100 16437         ; magic workbench to Experimentation room
 M 1 16001 35 16001          ; enforcer eyes, the guards of the city
 E 1 16001 0 5           ; wears eye plate
 M 1 16001 35 16008          ; these ones walk the streets

--- a/server/area/vampcat.are
+++ b/server/area/vampcat.are
@@ -4339,6 +4339,14 @@ E
 jade stone~
 The jade stone glows a brilliant green. You feel somehow more physically
 resilient when you hold it in your hand.~
+#9717
+bench workbench~
+a spellcrafting bench~
+A workbench for magical crafting stands here.~
+~
+41 64 0
+10~ 0~ 0~ 0~
+1000 0 0
 #0
 
 
@@ -7080,6 +7088,7 @@ S
 
 
 #RESETS
+O 1 9717 100 9533           magical bench to Velkyn's Laboratory
 O 1 9500 100 9501           meat scraps to Rubbish room
 *
 M 1 9500 1 9501         a dying man to Rubbish room

--- a/server/area/witch.are
+++ b/server/area/witch.are
@@ -96,7 +96,7 @@ A black robed witch cackles insanely to herself.
 ~
 The witch mutters and cackles away to herself.  She appears to be out of her
 mind, her eyes are glazed over and she looks right through you.  Her robes
-are almost compelely ruined, nothing but rags now.
+are almost completely ruined, nothing but rags now.
 ~
 2|64 8192 -350 S
 35 0 0 0d0+0 0d0+0
@@ -259,6 +259,14 @@ A pair of hunter's bracers are here.~
 5 0 0
 A
 13 50
+#10108
+bench workbench~
+a spellcrafting bench~
+A workbench for magical crafting stands here.~
+~
+41 64 0
+10~ 0~ 0~ 0~
+1000 0 0
 #0
 
 #ROOMS
@@ -1916,6 +1924,7 @@ S
 #0
 
 #RESETS
+O 1 10108 100 10148             magical bench to A Laboratory
 D 0 10114 0 1                   close north in Tower Gates
 M 0 10102 3 10102               add a brown bear to A Woody Path
 E 0 10103 0 16                      equip teeth (wield)

--- a/server/area/yitrite.are
+++ b/server/area/yitrite.are
@@ -754,6 +754,14 @@ A small glass of whiskey lies here.~
 10 0 1|16384
 40~ heal~ heal~ heal~
 12 0 0
+#24037
+forge~
+a forge~
+A large forge dominates the room.~
+~
+40 1 0
+10~ 0~ 0~ 0~
+1000 0 0
 #0
 
 
@@ -4720,6 +4728,8 @@ M 1 24000 1 24163              The Dragon to The charred mines.
 E 1 24002 100 0                The Eye of The Dragon
 E 1 24000 100 11               A Scale of The Dragon
 E 1 24001 100 16               A Talon of The Dragon
+*
+O 1 24037 100 24023           A forge to The Cobresh Smithy
 S
 
 #SHOPS

--- a/server/src/act_wiz.c
+++ b/server/src/act_wiz.c
@@ -919,7 +919,7 @@ void do_ostat( CHAR_DATA *ch, char *argument )
                 obj->weight, get_obj_weight( obj ) );
         strcat( buf1, buf );
 
-        sprintf( buf, "Type: {G%s{x  ",item_type_name( obj ));
+        sprintf( buf, "Type: {G%s{x [{W%d{x] ",item_type_name( obj ), obj->item_type);
         strcat( buf1, buf );
 
         sprintf( buf, "\n\r");
@@ -4490,7 +4490,9 @@ void do_rename( CHAR_DATA *ch, char *argument )
          * Place a few restrictions
          */
 
-        if (obj->item_type == ITEM_CLAN_OBJECT || !is_obj_owner(obj, ch))
+        if ( ( obj->item_type == ITEM_CLAN_OBJECT
+        ||    !is_obj_owner( obj, ch ) )
+        &&    !IS_IMMORTAL( ch ) )
         {
                 send_to_char("You may not rename that item.\n\r", ch);
                 return;

--- a/server/src/db.c
+++ b/server/src/db.c
@@ -2992,6 +2992,8 @@ OBJ_DATA *create_object (OBJ_INDEX_DATA *pObjIndex, int level)
             case ITEM_LOCK_PICK:
             case ITEM_WHETSTONE:
             case ITEM_MITHRIL:
+            case ITEM_CRAFT:
+            case ITEM_SPELLCRAFT:
                 break;
 
             case ITEM_TREASURE:

--- a/server/src/handler.c
+++ b/server/src/handler.c
@@ -2172,6 +2172,8 @@ char *item_type_name( OBJ_DATA *obj  )
             case ITEM_MITHRIL:          return "mithril";
             case ITEM_WHETSTONE:        return "whetstone";
             case ITEM_ANVIL:            return "anvil";
+            case ITEM_CRAFT:            return "crafting";
+            case ITEM_SPELLCRAFT:       return "spellcrafting";
         }
 
         for ( in_obj = obj; in_obj->in_obj; in_obj = in_obj->in_obj )

--- a/server/src/magic.c
+++ b/server/src/magic.c
@@ -1307,7 +1307,13 @@ void spell_continual_light (int sn, int level, CHAR_DATA *ch, void *vo)
 {
         OBJ_DATA *light;
         bool in_sc_room;
+        int obj_spellcraft_bonus;
+        int mod_room_bonus;
+
         in_sc_room = FALSE;
+        obj_spellcraft_bonus = get_spellcraft_obj_bonus( ch );
+        mod_room_bonus = CRAFT_BONUS_CONTINUAL_LIGHT + obj_spellcraft_bonus;
+
 
         if (IS_SET( ch->in_room->room_flags, ROOM_SPELLCRAFT ))
         {
@@ -1323,7 +1329,7 @@ void spell_continual_light (int sn, int level, CHAR_DATA *ch, void *vo)
         if ( in_sc_room )
         {
                 set_obj_owner(light, ch->name);
-                light->timer = ( ch->level * 2 * CRAFT_BONUS_CONTINUAL_LIGHT ) / 100;
+                light->timer = ( ch->level * 2 * mod_room_bonus ) / 100;
         }
 
         obj_to_room( light, ch->in_room );
@@ -1354,7 +1360,13 @@ void spell_create_food ( int sn, int level, CHAR_DATA *ch, void *vo )
 {
         OBJ_DATA *mushroom;
         bool in_sc_room;
+        int obj_spellcraft_bonus;
+        int mod_room_bonus;
+
         in_sc_room = FALSE;
+        obj_spellcraft_bonus = get_spellcraft_obj_bonus( ch );
+        mod_room_bonus = CRAFT_BONUS_CREATE_FOOD + obj_spellcraft_bonus;
+
 
         if (IS_SET( ch->in_room->room_flags, ROOM_SPELLCRAFT ))
         {
@@ -1366,7 +1378,7 @@ void spell_create_food ( int sn, int level, CHAR_DATA *ch, void *vo )
 
 
         mushroom = create_object( get_obj_index( OBJ_VNUM_MUSHROOM ), 0 );
-        mushroom->value[0] = (in_sc_room) ? 5 + ( level * CRAFT_BONUS_CREATE_FOOD ) / 100 : 5 + level;
+        mushroom->value[0] = (in_sc_room) ? 5 + ( level * mod_room_bonus ) / 100 : 5 + level;
         obj_to_room( mushroom, ch->in_room );
 
         act( "$p suddenly appears.", ch, mushroom, NULL, TO_CHAR );
@@ -1379,7 +1391,12 @@ void spell_create_spring( int sn, int level, CHAR_DATA *ch, void *vo )
 {
         OBJ_DATA *spring;
         bool in_sc_room;
+        int obj_spellcraft_bonus;
+        int mod_room_bonus;
+
         in_sc_room = FALSE;
+        obj_spellcraft_bonus = get_spellcraft_obj_bonus( ch );
+        mod_room_bonus = CRAFT_BONUS_CREATE_SPRING + obj_spellcraft_bonus;
 
         if (IS_SET( ch->in_room->room_flags, ROOM_SPELLCRAFT ))
         {
@@ -1390,7 +1407,7 @@ void spell_create_spring( int sn, int level, CHAR_DATA *ch, void *vo )
                 send_to_char( "{MYou use spellcrafting resources to give your magical spring more longevity!{x\n\r", ch);
 
         spring = create_object( get_obj_index( OBJ_VNUM_SPRING ), 0 );
-        spring->timer = ( in_sc_room ) ? ( level * CRAFT_BONUS_CREATE_SPRING )  / 100 : level;
+        spring->timer = ( in_sc_room ) ? ( level * mod_room_bonus )  / 100 : level;
         obj_to_room( spring, ch->in_room );
 
         act( "Water flows from $p.", ch, spring, NULL, TO_CHAR );
@@ -1404,7 +1421,12 @@ void spell_create_water( int sn, int level, CHAR_DATA *ch, void *vo )
         OBJ_DATA *obj   = (OBJ_DATA *) vo;
         int       water;
         bool in_sc_room;
+        int obj_spellcraft_bonus;
+        int mod_room_bonus;
+
         in_sc_room = FALSE;
+        obj_spellcraft_bonus = get_spellcraft_obj_bonus( ch );
+        mod_room_bonus = CRAFT_BONUS_CREATE_WATER + obj_spellcraft_bonus;
 
         if (IS_SET( ch->in_room->room_flags, ROOM_SPELLCRAFT ))
         {
@@ -1427,7 +1449,7 @@ void spell_create_water( int sn, int level, CHAR_DATA *ch, void *vo )
                 send_to_char( "{MYour use of spellcrafting resources increases the quantity of water you create!{x\n\r", ch);
 
         water = UMIN( level * ( weather_info.sky >= SKY_RAINING ? 4 : 2 ), obj->value[0] - obj->value[1] );
-        water = ( in_sc_room ) ? ( water * CRAFT_BONUS_CREATE_WATER )  / 100 : water;
+        water = ( in_sc_room ) ? ( water * mod_room_bonus )  / 100 : water;
         water = ( water >= ( obj->value[0] - obj->value[1] ) ) ? ( obj->value[0] - obj->value[1] ) : water;
 
         if ( water > 0 )
@@ -2382,7 +2404,12 @@ void spell_enchant_weapon(int sn, int level, CHAR_DATA *ch, void *vo)
         OBJ_DATA *obj = (OBJ_DATA *) vo;
         AFFECT_DATA *paf;
         bool in_sc_room;
+        int obj_spellcraft_bonus;
+        int mod_room_bonus;
+
         in_sc_room = FALSE;
+        obj_spellcraft_bonus = get_spellcraft_obj_bonus( ch );
+        mod_room_bonus = CRAFT_BONUS_ENCHANT_WEAPON + obj_spellcraft_bonus;
 
         if (IS_SET( ch->in_room->room_flags, ROOM_SPELLCRAFT ))
         {
@@ -2413,7 +2440,7 @@ void spell_enchant_weapon(int sn, int level, CHAR_DATA *ch, void *vo)
         paf->type       = sn;
         paf->duration   = -1;
         paf->location   = APPLY_HITROLL;
-        paf->modifier   = ( in_sc_room ) ? ( level / ( ( 5 * 100 ) / CRAFT_BONUS_ENCHANT_WEAPON ) ) : level / 5;
+        paf->modifier   = ( in_sc_room ) ? ( level / ( ( 5 * 100 ) / mod_room_bonus ) ) : level / 5;
         paf->bitvector  = 0;
         paf->next       = obj->affected;
         obj->affected   = paf;
@@ -2431,7 +2458,7 @@ void spell_enchant_weapon(int sn, int level, CHAR_DATA *ch, void *vo)
         paf->type       = sn;
         paf->duration   = -1;
         paf->location   = APPLY_DAMROLL;
-        paf->modifier   = ( in_sc_room ) ? ( level / ( ( 10 * 100 ) / CRAFT_BONUS_ENCHANT_WEAPON ) ) : level / 10;
+        paf->modifier   = ( in_sc_room ) ? ( level / ( ( 10 * 100 ) / mod_room_bonus ) ) : level / 10;
         paf->bitvector  = 0;
         paf->next       = obj->affected;
         obj->affected   = paf;
@@ -3809,7 +3836,12 @@ void spell_stone_skin( int sn, int level, CHAR_DATA *ch, void *vo )
         CHAR_DATA  *victim = (CHAR_DATA *) vo;
         AFFECT_DATA af;
         bool in_sc_room;
+        int obj_spellcraft_bonus;
+        int mod_room_bonus;
+
         in_sc_room = FALSE;
+        obj_spellcraft_bonus = get_spellcraft_obj_bonus( ch );
+        mod_room_bonus = CRAFT_BONUS_STONE_SKIN + obj_spellcraft_bonus;
 
         if (IS_SET( ch->in_room->room_flags, ROOM_SPELLCRAFT ))
         {
@@ -3820,12 +3852,12 @@ void spell_stone_skin( int sn, int level, CHAR_DATA *ch, void *vo )
                 return;
 
         if ( in_sc_room )
-                send_to_char( "{MUsing spellcrafting reagents increases the toughness of your skin!{x\n\r", ch);
+                send_to_char( "{MUsing spellcrafting reagents increases the hardness of your petrified skin!{x\n\r", ch);
 
         af.type      = sn;
         af.duration  = level;
         af.location  = APPLY_AC;
-        af.modifier  = ( in_sc_room ) ? - (  ( 40 * CRAFT_BONUS_STONE_SKIN ) / 100 ) : -40;
+        af.modifier  = ( in_sc_room ) ? - (  ( 40 * mod_room_bonus ) / 100 ) : -40;
         af.bitvector = 0;
         affect_to_char( victim, &af );
 
@@ -3896,7 +3928,12 @@ void spell_summon_familiar( int sn, int level, CHAR_DATA *ch, void *vo )
         CHAR_DATA *victim= (CHAR_DATA *) vo;
         char    buf     [MAX_STRING_LENGTH];
         bool in_sc_room;
+        int obj_spellcraft_bonus;
+        int mod_room_bonus;
+
         in_sc_room = FALSE;
+        obj_spellcraft_bonus = get_spellcraft_obj_bonus( ch );
+        mod_room_bonus = CRAFT_BONUS_SUMMON_FAMILIAR + obj_spellcraft_bonus;
 
         if (IS_SET( ch->in_room->room_flags, ROOM_SPELLCRAFT ))
         {
@@ -3925,7 +3962,7 @@ void spell_summon_familiar( int sn, int level, CHAR_DATA *ch, void *vo )
         if (in_sc_room)
                 send_to_char("{MThe use of spellcrafting reagents increases the hardiness of your familiar!\n\r{x", ch);
 
-        victim->max_hit = ( in_sc_room ) ? ( victim->max_hit * CRAFT_BONUS_SUMMON_FAMILIAR ) / 100 : victim->max_hit;
+        victim->max_hit = ( in_sc_room ) ? ( victim->max_hit * mod_room_bonus ) / 100 : victim->max_hit;
         victim->hit = victim->max_hit;
 
         sprintf( buf, "You raise your hands and the form of %s appears before you.\n\r",
@@ -3945,7 +3982,12 @@ void spell_summon_demon( int sn, int level, CHAR_DATA *ch, void *vo )
         char buf [MAX_STRING_LENGTH];
         int count;
         bool in_sc_room;
+        int obj_spellcraft_bonus;
+        int mod_room_bonus;
+
         in_sc_room = FALSE;
+        obj_spellcraft_bonus = get_spellcraft_obj_bonus( ch );
+        mod_room_bonus = CRAFT_BONUS_SUMMON_DEMON + obj_spellcraft_bonus;
 
         if (IS_SET( ch->in_room->room_flags, ROOM_SPELLCRAFT ))
         {
@@ -3984,22 +4026,22 @@ void spell_summon_demon( int sn, int level, CHAR_DATA *ch, void *vo )
         if (ch->class == CLASS_SHAPE_SHIFTER)
         {
                 mob = create_mobile(get_mob_index(MOB_VNUM_LESSER));
-                mob->level = (in_sc_room) ? ( ( ch->level * CRAFT_BONUS_SUMMON_DEMON ) / 100 ) - 10 : ch->level - 10;
+                mob->level = (in_sc_room) ? ( ( ch->level * mod_room_bonus ) / 100 ) - 10 : ch->level - 10;
                 if ( mob->level > ch->level )
                         mob->level = ch->level;
-                mob->max_hit = (in_sc_room) ? ( ( mob->level * CRAFT_BONUS_SUMMON_DEMON ) / 100 ) * 10
-                        + number_range(mob->level * mob->level/4, ( mob->level * ( ( mob->level * CRAFT_BONUS_SUMMON_DEMON ) / 100 ) ) ) : mob->level * 10
+                mob->max_hit = (in_sc_room) ? ( ( mob->level * mod_room_bonus ) / 100 ) * 10
+                        + number_range(mob->level * mob->level/4, ( mob->level * ( ( mob->level * mod_room_bonus ) / 100 ) ) ) : mob->level * 10
                         + number_range(mob->level * mob->level/4, mob->level * mob->level);
                 mob->hit = mob->max_hit;
         }
         else
         {
                 mob = create_mobile(get_mob_index(MOB_VNUM_DEMON));
-                mob->level = (in_sc_room) ? ( ( ch->level * CRAFT_BONUS_SUMMON_DEMON ) / 100 ) - 10 : ch->level - 10;
+                mob->level = (in_sc_room) ? ( ( ch->level * mod_room_bonus ) / 100 ) - 10 : ch->level - 10;
                 if ( mob->level > ch->level )
                         mob->level = ch->level;
-                mob->max_hit = (in_sc_room) ? ( ( mob->level * CRAFT_BONUS_SUMMON_DEMON ) / 100 ) * 8
-                        + number_range(mob->level * mob->level/4, ( mob->level * ( ( mob->level * CRAFT_BONUS_SUMMON_DEMON ) / 100 ) ) ) : mob->level * 8
+                mob->max_hit = (in_sc_room) ? ( ( mob->level * mod_room_bonus ) / 100 ) * 8
+                        + number_range(mob->level * mob->level/4, ( mob->level * ( ( mob->level * mod_room_bonus ) / 100 ) ) ) : mob->level * 8
                         + number_range(mob->level * mob->level/4, mob->level * mob->level);
                 mob->hit = mob->max_hit;
         }
@@ -5094,7 +5136,12 @@ void spell_enhance_armor (int sn, int level, CHAR_DATA *ch, void *vo )
         OBJ_DATA    *obj = (OBJ_DATA *) vo;
         AFFECT_DATA *paf;
         bool in_sc_room;
+        int obj_spellcraft_bonus;
+        int mod_room_bonus;
+
         in_sc_room = FALSE;
+        obj_spellcraft_bonus = get_spellcraft_obj_bonus( ch );
+        mod_room_bonus = CRAFT_BONUS_ENHANCE_ARMOR + obj_spellcraft_bonus;
 
         if (IS_SET( ch->in_room->room_flags, ROOM_SPELLCRAFT ))
         {
@@ -5127,7 +5174,7 @@ void spell_enhance_armor (int sn, int level, CHAR_DATA *ch, void *vo )
         paf->location = APPLY_AC;
         paf->bitvector = 0;
         paf->next = obj->affected;
-        paf->modifier   = ( in_sc_room ) ? - ( level / ( ( 8 * 100 ) / CRAFT_BONUS_ENHANCE_ARMOR ) ) : - level / 8;
+        paf->modifier   = ( in_sc_room ) ? - ( level / ( ( 8 * 100 ) / mod_room_bonus ) ) : - level / 8;
 
         obj->affected = paf;
 
@@ -5179,7 +5226,12 @@ void spell_flesh_armor ( int sn, int level, CHAR_DATA *ch, void *vo )
         CHAR_DATA  *victim = (CHAR_DATA *) vo;
         AFFECT_DATA af;
         bool in_sc_room;
+        int obj_spellcraft_bonus;
+        int mod_room_bonus;
+
         in_sc_room = FALSE;
+        obj_spellcraft_bonus = get_spellcraft_obj_bonus( ch );
+        mod_room_bonus = CRAFT_BONUS_FLESH_ARMOR + obj_spellcraft_bonus;
 
         if (IS_SET( ch->in_room->room_flags, ROOM_SPELLCRAFT ))
         {
@@ -5190,12 +5242,12 @@ void spell_flesh_armor ( int sn, int level, CHAR_DATA *ch, void *vo )
                 return;
 
         if ( in_sc_room )
-                send_to_char( "{MYour use of spellcrafting resources increases the thickness of your spell armor!{x\n\r", ch);
+                send_to_char( "{MYour use of spellcrafting resources increases the toughness of your flesh armor!{x\n\r", ch);
 
         af.type = sn;
         af.duration = level;
         af.location = APPLY_AC;
-        af.modifier = ( in_sc_room ) ? - (  ( 40 * CRAFT_BONUS_FLESH_ARMOR ) / 100 ) : -40;
+        af.modifier = ( in_sc_room ) ? - (  ( 40 * mod_room_bonus ) / 100 ) : -40;
         af.bitvector = 0;
         affect_to_char( victim, &af );
 
@@ -6010,7 +6062,12 @@ void spell_bless_weapon( int sn, int level, CHAR_DATA *ch, void *vo )
         OBJ_DATA    *obj = (OBJ_DATA *) vo;
         AFFECT_DATA *paf;
         bool in_sc_room;
+        int obj_spellcraft_bonus;
+        int mod_room_bonus;
+
         in_sc_room = FALSE;
+        obj_spellcraft_bonus = get_spellcraft_obj_bonus( ch );
+        mod_room_bonus = CRAFT_BONUS_BLESS_WEAPON + obj_spellcraft_bonus;
 
         if (IS_SET( ch->in_room->room_flags, ROOM_SPELLCRAFT ))
         {
@@ -6041,7 +6098,7 @@ void spell_bless_weapon( int sn, int level, CHAR_DATA *ch, void *vo )
         paf->type       = sn;
         paf->duration   = -1;
         paf->location   = APPLY_MANA;
-        paf->modifier   = ( in_sc_room ) ? ( 2 * ( level * CRAFT_BONUS_BLESS_WEAPON / 100 ) ) : 2 * level;
+        paf->modifier   = ( in_sc_room ) ? ( 2 * ( level * mod_room_bonus / 100 ) ) : 2 * level;
         paf->bitvector  = 0;
         paf->next       = obj->affected;
         obj->affected   = paf;
@@ -6059,7 +6116,7 @@ void spell_bless_weapon( int sn, int level, CHAR_DATA *ch, void *vo )
         paf->type       = sn;
         paf->duration   = -1;
         paf->location   = APPLY_SAVING_SPELL;
-        paf->modifier   = ( in_sc_room ) ? - ( level / ( ( 5 * 100 ) / CRAFT_BONUS_BLESS_WEAPON ) ) : - level / 5;
+        paf->modifier   = ( in_sc_room ) ? - ( level / ( ( 5 * 100 ) / mod_room_bonus ) ) : - level / 5;
         paf->bitvector  = 0;
         paf->next       = obj->affected;
         obj->affected   = paf;
@@ -6094,7 +6151,12 @@ void spell_bark_skin( int sn, int level, CHAR_DATA *ch, void *vo )
         CHAR_DATA  *victim = (CHAR_DATA *) vo;
         AFFECT_DATA af;
         bool in_sc_room;
+        int obj_spellcraft_bonus;
+        int mod_room_bonus;
+
         in_sc_room = FALSE;
+        obj_spellcraft_bonus = get_spellcraft_obj_bonus( ch );
+        mod_room_bonus = CRAFT_BONUS_BARK_SKIN + obj_spellcraft_bonus;
 
         if ( is_affected( victim, sn ) )
                 return;
@@ -6108,9 +6170,9 @@ void spell_bark_skin( int sn, int level, CHAR_DATA *ch, void *vo )
                 send_to_char( "{MYour bark skin spell is improved by the use of magical components!{x\n\r", victim);
 
         af.type      = sn;
-        af.duration  = ( in_sc_room ) ? ( 2 * ( level * CRAFT_BONUS_BARK_SKIN / 100 ) ) : 2 * level;
+        af.duration  = ( in_sc_room ) ? ( 2 * ( level * mod_room_bonus / 100 ) ) : 2 * level;
         af.location  = APPLY_AC;
-        af.modifier  = ( in_sc_room ) ? ( ( -30 * CRAFT_BONUS_BARK_SKIN ) / 100 ) : -30 ;
+        af.modifier  = ( in_sc_room ) ? ( ( -30 * mod_room_bonus ) / 100 ) : -30 ;
         af.bitvector = 0;
 
         affect_to_char( victim, &af );
@@ -6301,7 +6363,12 @@ void spell_recharge_item( int sn, int level, CHAR_DATA *ch, void *vo )
 {
         OBJ_DATA *obj = (OBJ_DATA *) vo;
         bool in_sc_room;
+        int obj_spellcraft_bonus;
+        int mod_room_bonus;
+
         in_sc_room = FALSE;
+        obj_spellcraft_bonus = get_spellcraft_obj_bonus( ch );
+        mod_room_bonus = CRAFT_BONUS_RECHARGE_ITEM + obj_spellcraft_bonus;
 
         if (IS_SET( ch->in_room->room_flags, ROOM_SPELLCRAFT ))
         {
@@ -6358,13 +6425,13 @@ void spell_recharge_item( int sn, int level, CHAR_DATA *ch, void *vo )
         if ( obj->value[2] > obj->value[1]
         &&   in_sc_room == TRUE )
         {
-                if ( number_percent() > ( CRAFT_BONUS_RECHARGE_ITEM - 100 ) )
+                if ( number_percent() > ( mod_room_bonus - 100 ) )
                 {
                         act ("... but it still shudders violently and implodes!", ch, obj, NULL, TO_CHAR );
                         extract_obj ( obj );
                 }
                 else {
-                        if ( number_percent() > ( CRAFT_BONUS_RECHARGE_ITEM - 100 ) )
+                        if ( number_percent() > ( mod_room_bonus - 100 ) )
                         {
                                 obj->value[1]++;
                                 act ("You increase its charge capacity!", ch, obj, NULL, TO_CHAR );

--- a/server/src/merc.h
+++ b/server/src/merc.h
@@ -1792,6 +1792,8 @@ extern  WANTED_DATA *wanted_list_last;
 #define ITEM_ARMOURERS_HAMMER                   37
 #define ITEM_MITHRIL                            38
 #define ITEM_WHETSTONE                          39
+#define ITEM_CRAFT                              40 /* Increase bonus to crafting that takes place in ROOM_CRAFT */
+#define ITEM_SPELLCRAFT                         41 /* Increase bonus to spellcrafting that takes place in ROOM_SPELLCRAFT */
 
 
 /*
@@ -4053,6 +4055,8 @@ bool  is_obj_owner                            ( OBJ_DATA *obj, CHAR_DATA *ch );
 void  destroy_clan_items                      ( CHAR_DATA *ch );
 bool  has_ego_item_effect                     ( CHAR_DATA *ch, int flag );
 void  player_leaves_clan                      ( CHAR_DATA *ch );
+int   get_craft_obj_bonus                     ( CHAR_DATA *ch );
+int   get_spellcraft_obj_bonus                ( CHAR_DATA *ch );
 
 /* act_wiz.c */
 ROOM_INDEX_DATA *       find_location   args( ( CHAR_DATA *ch, char *arg ) );

--- a/server/src/skill.c
+++ b/server/src/skill.c
@@ -1678,6 +1678,7 @@ void do_break_wrist (CHAR_DATA *ch, char *argument)
 /*
  *  sharpen weapon skill _ Brutus
  */
+
 void do_sharpen (CHAR_DATA *ch, char *argument)
 {
         OBJ_DATA *obj;
@@ -1685,7 +1686,14 @@ void do_sharpen (CHAR_DATA *ch, char *argument)
         char arg [ MAX_INPUT_LENGTH ];
         AFFECT_DATA *paf;
         bool in_c_room;
+        int obj_craft_bonus;
+        int mod_room_bonus;
+
+        obj_craft_bonus = get_craft_obj_bonus( ch );
+        mod_room_bonus = CRAFT_BONUS_SHARPEN + obj_craft_bonus;
+
         in_c_room = FALSE;
+
 
         if (IS_SET( ch->in_room->room_flags, ROOM_CRAFT ))
         {
@@ -1792,12 +1800,12 @@ void do_sharpen (CHAR_DATA *ch, char *argument)
         paf->type           = gsn_sharpen;
         paf->duration       = -1;
         paf->location       = APPLY_DAMROLL;
-        paf->modifier       = ( in_c_room ) ? 2 + ( ch->level / ( ( 5 * 100 ) / CRAFT_BONUS_SHARPEN ) ) : 2 + ch->level / 5;
+        paf->modifier       = ( in_c_room ) ? 2 + ( ch->level / ( ( 5 * 100 ) / mod_room_bonus ) ) : 2 + ch->level / 5;
         paf->bitvector      = 0;
         paf->next           = obj->affected;
         obj->affected       = paf;
 
-        obj->timer          = (in_c_room) ? ( ( 30  * CRAFT_BONUS_SHARPEN ) / 100 ) * (ch->level / 15) + 60 : 30 * (ch->level / 15) + 60;  /* 1-2 real hours */
+        obj->timer          = (in_c_room) ? ( ( 30  * mod_room_bonus ) / 100 ) * (ch->level / 15) + 60 : 30 * (ch->level / 15) + 60;  /* 1-2 real hours */
         set_obj_owner(obj, ch->name);
 }
 
@@ -1813,7 +1821,13 @@ void do_forge (CHAR_DATA *ch, char *argument)
         AFFECT_DATA *paf;
         bool found;
         bool in_c_room;
+        int obj_craft_bonus;
+        int mod_room_bonus;
+
         in_c_room = FALSE;
+
+        obj_craft_bonus = get_craft_obj_bonus( ch );
+        mod_room_bonus = CRAFT_BONUS_FORGE + obj_craft_bonus;
 
         if (IS_SET( ch->in_room->room_flags, ROOM_CRAFT ))
         {
@@ -1929,12 +1943,12 @@ void do_forge (CHAR_DATA *ch, char *argument)
         paf->type           = gsn_forge;
         paf->duration       = -1;
         paf->location       = APPLY_AC;
-        paf->modifier       = (in_c_room) ? 0 - ( ch->level / ( ( 5 * 100 ) / CRAFT_BONUS_FORGE ) ) : 0 - ch->level / 5;
+        paf->modifier       = (in_c_room) ? 0 - ( ch->level / ( ( 5 * 100 ) / mod_room_bonus ) ) : 0 - ch->level / 5;
         paf->bitvector      = 0;
         paf->next           = obj->affected;
         obj->affected       = paf;
 
-        obj->timer = (in_c_room) ? ( ( 30  * CRAFT_BONUS_FORGE ) / 100 ) * (ch->level / 15) + 60 : 30 * (ch->level / 15) + 60;  /* 1-2 real hours */
+        obj->timer = (in_c_room) ? ( ( 30  * mod_room_bonus ) / 100 ) * (ch->level / 15) + 60 : 30 * (ch->level / 15) + 60;  /* 1-2 real hours */
         set_obj_owner(obj, ch->name);
 }
 
@@ -3034,7 +3048,6 @@ void do_gather (CHAR_DATA *ch, char *arg)
 
         return;
 }
-
 
 void do_classify( CHAR_DATA *ch, char *arg )
 {

--- a/server/src/update.c
+++ b/server/src/update.c
@@ -1712,7 +1712,7 @@ void obj_update()
                         else if (obj->item_type == ITEM_WEAPON
                                  && (IS_OBJ_STAT(obj, ITEM_SHARP) || IS_OBJ_STAT(obj, ITEM_BLADE_THIRST)))
                         {
-                                act("$p's blade is beginning to deteriorate.",
+                                act("$p is beginning to deteriorate.",
                                     obj->carried_by, obj, NULL, TO_CHAR);
                         }
 


### PR DESCRIPTION
- Two new item types, ITEM_CRAFT and ITEM_SPELLCRAFT.  Items of this type use value0 as a percentage multiplier to the ordinary bonuses gained to crafting skills/spelling in a ROOM_CRAFT or ROOM_SPELLCRAFT
- Have added them to the harder to get-to/would be nice if people went to these areas more crafting rooms with values that reflect the difficulty of getting there and the desirability of sending people there
- Also minor change to ostat (now shows ITEM_TYPE int) and various spelling etc fixes I noticed 