### PR TITLE
Fix capitalization errors for act strings using leading $n anchors

### DIFF
--- a/server/src/act_move.c
+++ b/server/src/act_move.c
@@ -2939,7 +2939,7 @@ void do_pattern(CHAR_DATA* ch, char* argument)
                 ch->mana -= 200;
                 ch->pcdata->pattern = ch->in_room->vnum;
                 send_to_char("{CYou create a mystical pattern before you and imbue it with magical energy.{x\n\r", ch);
-                act("{Y$n creates a mystical pattern before them and imbues it with magical energy.{x",
+                act("{Y$c creates a mystical pattern before them and imbues it with magical energy.{x",
                         ch, NULL, NULL, TO_ROOM);
                 WAIT_STATE(ch, 2 * PULSE_VIOLENCE);
                 return;
@@ -2983,7 +2983,7 @@ void do_pattern(CHAR_DATA* ch, char* argument)
                 return;
         }
 
-        act ("{Y$n steps into a mystic pattern and is gone.{x", ch, NULL, NULL, TO_ROOM);
+        act ("{Y$c steps into a mystic pattern and is gone.{x", ch, NULL, NULL, TO_ROOM);
         send_to_char("{YYou create a mystic pattern and step into it...{x\n\r\n\r", ch);
 
         char_from_room(ch);

--- a/server/src/board.c
+++ b/server/src/board.c
@@ -533,7 +533,7 @@ static void do_nwrite (CHAR_DATA *ch, char *argument)
                 ch->pcdata->in_progress->date = str_dup (strtime);
         }
 
-        act ("{G$n starts writing a note.{x", ch, NULL, NULL, TO_ROOM);
+        act ("{G$c starts writing a note.{x", ch, NULL, NULL, TO_ROOM);
 
         /* Begin writing the note ! */
         sprintf (buf, "You are now %s a new note on the {W%s{x board.\n\r"
@@ -1230,7 +1230,7 @@ void handle_con_note_finish (DESCRIPTOR_DATA *d, char * argument)
                                 d->connected = CON_PLAYING;
                                 /* remove AFK status */
                                 ch->pcdata->in_progress = NULL;
-                                act ("{G$n finishes $s note.{x", ch, NULL, NULL, TO_ROOM);
+                                act ("{G$c finishes $s note.{x", ch, NULL, NULL, TO_ROOM);
 
                                 if (ch->pcdata->board->announce_post)
                                 {

--- a/server/src/deity.c
+++ b/server/src/deity.c
@@ -3041,12 +3041,12 @@ void prayer_rescue (CHAR_DATA *ch)
         if (ch->mount)
                 strip_mount(ch);
 
-        act("{W$n is surrounded by holy light and disappears!{x", ch, NULL, NULL, TO_ROOM);
+        act("{W$c is surrounded by holy light and disappears!{x", ch, NULL, NULL, TO_ROOM);
         send_to_char("{WYou are surrounded by holy light!{x\n\r\n\r", ch);
 
         char_from_room(ch);
         char_to_room(ch, get_room_index(ROOM_VNUM_TEMPLE));
-        act("{W$n appears in a flash of holy light!{x", ch, NULL, NULL, TO_ROOM);
+        act("{W$c appears in a flash of holy light!{x", ch, NULL, NULL, TO_ROOM);
 
         do_look(ch, "");
 
@@ -3062,7 +3062,7 @@ void prayer_healing (CHAR_DATA *ch)
         if (!allow_deity_command (ch))
                 return;
 
-        act("{Y$n is briefly surrounded by a warm golden fire!{x", ch, NULL, NULL, TO_ROOM);
+        act("{Y$c is briefly surrounded by a warm golden fire!{x", ch, NULL, NULL, TO_ROOM);
         sprintf(buf, "{C%s revives your battered and weary body!{x\n\r",
                 deity_info_table[ch->pcdata->deity_patron].name);
         send_to_char(buf, ch);
@@ -3379,7 +3379,7 @@ void prayer_transport (CHAR_DATA *ch, char *text)
 
         patron_message("As you wish.", ch);
 
-        act("{C$n disappears in a flash of holy light!{x",
+        act("{C$c disappears in a flash of holy light!{x",
             ch, NULL, NULL, TO_ROOM);
 
         char_from_room(ch);
@@ -3387,15 +3387,15 @@ void prayer_transport (CHAR_DATA *ch, char *text)
 
         if (ch->mount)
         {
-                act ("{W$n disappears in a flash of holy light!{x", ch->mount, NULL, NULL, TO_ROOM);
+                act ("{W$c disappears in a flash of holy light!{x", ch->mount, NULL, NULL, TO_ROOM);
                 char_from_room(ch->mount);
                 char_to_room(ch->mount, victim->in_room);
         }
 
-        act("{C$n appears in a flash of holy light!{x", ch, NULL, NULL, TO_ROOM);
+        act("{C$c appears in a flash of holy light!{x", ch, NULL, NULL, TO_ROOM);
 
         if (ch->mount)
-                act("{C$n appears in a flash of holy light!{x", ch->mount, NULL, NULL, TO_ROOM);
+                act("{C$c appears in a flash of holy light!{x", ch->mount, NULL, NULL, TO_ROOM);
 
         send_to_char("\n\r", ch);
         do_look(ch, "");

--- a/server/src/fight.c
+++ b/server/src/fight.c
@@ -661,7 +661,7 @@ bool one_hit (CHAR_DATA *ch, CHAR_DATA *victim, int dt)
                         else if (dt == gsn_joust || dt == gsn_dive )
                                 dam *= 2 + (ch->level / 20);
 
-                        else if (dt == gsn_lunge) 
+                        else if (dt == gsn_lunge)
                         {
                                 dam += dam / 2;
 
@@ -672,7 +672,7 @@ bool one_hit (CHAR_DATA *ch, CHAR_DATA *victim, int dt)
                                 if (ch->rage > (ch->max_rage * 3 / 4))
                                         dam += dam / 10;
                                 else if (ch->rage < ch->max_rage / 4)
-                                        dam -= dam / 10;                                                
+                                        dam -= dam / 10;
                         }
 
                         else if (dt == gsn_shoot)
@@ -695,7 +695,7 @@ bool one_hit (CHAR_DATA *ch, CHAR_DATA *victim, int dt)
                                 if (ch->rage > (ch->max_rage * 3 / 4))
                                         dam += dam / 10;
                                 else if (ch->rage < ch->max_rage / 4)
-                                        dam -= dam / 10;                                                
+                                        dam -= dam / 10;
                         }
 
                         else if (dt == gsn_second_circle)
@@ -2433,7 +2433,7 @@ void group_gain (CHAR_DATA *ch, CHAR_DATA *victim)
                 {
                         sprintf(buf, "{WYou gained a total of %d experience points for the kill!{x\n\r", total_xp);
                         send_to_char(buf, gch);
-                        total_xp = 0;                
+                        total_xp = 0;
                         total_message = 0;
                 }
 
@@ -2512,7 +2512,7 @@ void group_gain (CHAR_DATA *ch, CHAR_DATA *victim)
                                 && (!can_use_poison_weapon(ch))))
                         {
                                 act ("{YYou are zapped by $p and drop it.{x", ch, obj, NULL, TO_CHAR);
-                                act ("{Y$n is zapped by $p and drops it.{x",   ch, obj, NULL, TO_ROOM);
+                                act ("{Y$c is zapped by $p and drops it.{x",   ch, obj, NULL, TO_ROOM);
                                 obj_from_char(obj);
                                 obj_to_room(obj, ch->in_room);
                         }
@@ -2791,19 +2791,19 @@ void dam_message (CHAR_DATA *ch, CHAR_DATA *victim, int dam, int dt, bool poison
                 if (dt > TYPE_HIT && poison)
                 {
                         sprintf(buf1, "Your poisoned %s %s $N%c",  attack, vp, punct);
-                        sprintf(buf2, "{W$n's poisoned %s{x %s {Wyou%c{x", attack, vp, punct);
-                        sprintf(buf3, "$n's poisoned %s %s $N%c",  attack, vp, punct);
+                        sprintf(buf2, "{W$c's poisoned %s{x %s {Wyou%c{x", attack, vp, punct);
+                        sprintf(buf3, "$c's poisoned %s %s $N%c",  attack, vp, punct);
                         sprintf(buf4, "Your poisoned %s %s you%c", attack, vp, punct);
-                        sprintf(buf5, "$n's poisoned %s %s $n%c",  attack, vp, punct);
+                        sprintf(buf5, "$c's poisoned %s %s $n%c",  attack, vp, punct);
                 }
 
                 else
                 {
                         sprintf(buf1, "Your %s %s $N%c",  attack, vp, punct);
-                        sprintf(buf2, "{W$n's %s{x %s {Wyou%c{x", attack, vp, punct);
-                        sprintf(buf3, "$n's %s %s $N%c",  attack, vp, punct);
+                        sprintf(buf2, "{W$c's %s{x %s {Wyou%c{x", attack, vp, punct);
+                        sprintf(buf3, "$c's %s %s $N%c",  attack, vp, punct);
                         sprintf(buf4, "Your %s %s you%c", attack, vp, punct);
-                        sprintf(buf5, "$n's %s %s $n%c",  attack, vp, punct);
+                        sprintf(buf5, "$c's %s %s $n%c",  attack, vp, punct);
                 }
         }
 
@@ -3961,11 +3961,11 @@ void do_smoke_bomb (CHAR_DATA *ch, char *argument)
         was_in = ch->in_room;
 
         /*
-         * Have 30 goes at randomly finding an exit to escape too          
+         * Have 30 goes at randomly finding an exit to escape too
          */
 
         for (attempt = 0; attempt < 30; attempt++)
-        {                
+        {
                 /* Randomly find an exit */
                 door = number_range(0, 5);
 
@@ -3978,7 +3978,7 @@ void do_smoke_bomb (CHAR_DATA *ch, char *argument)
                 {
                         continue;
                 }
-                
+
                 stop_fighting(ch, TRUE);
                 send_to_char ("{WYou drop a smoke bomb and escape!{x\n\r\n\r", ch);
                 act ("{W$c drops a smoke bomb and escapes!{x", ch, NULL, NULL, TO_ROOM);
@@ -3992,9 +3992,9 @@ void do_smoke_bomb (CHAR_DATA *ch, char *argument)
                 af.duration = 0;
                 af.location = APPLY_NONE;
                 af.modifier = 0;
-                af.bitvector = AFF_SNEAK;                
+                af.bitvector = AFF_SNEAK;
 
-                affect_to_char(ch, &af);                
+                affect_to_char(ch, &af);
 
                 /*
                  * I think this handles random rooms looping back on itself
@@ -4380,9 +4380,9 @@ void do_knife_toss (CHAR_DATA *ch, char *argument)
                                         act("{WYour knife catches $N in the face!{x", ch, NULL, victim, TO_CHAR);
 
                                         if (!IS_NPC(victim))
-                                                act("{W$n's knife catches you right in the face!{x", ch, NULL, victim, TO_VICT);
+                                                act("{W$c's knife catches you right in the face!{x", ch, NULL, victim, TO_VICT);
 
-                                        act("{W$n's knife catches $N in the face!{x", ch, NULL, victim, TO_NOTVICT);
+                                        act("{W$c's knife catches $N in the face!{x", ch, NULL, victim, TO_NOTVICT);
 
                                         dam *= 2;
                                 }
@@ -4976,9 +4976,9 @@ void do_decapitate (CHAR_DATA *ch, char *argument)
         if (number_percent() < chance)
         {
                 act ("{B$C's head is detached from $S neck!!{x", ch, NULL, victim, TO_CHAR);
-                act ("{B$n swings $s blade at $N, causing $N's head to separate from $S body and fly away!!{x",
+                act ("{B$c swings $s blade at $N, causing $N's head to separate from $S body and fly away!!{x",
                      ch, NULL, victim, TO_NOTVICT);
-                act ("{B$n DECAPITATES you!!{x", ch, NULL, victim, TO_VICT);
+                act ("{B$c DECAPITATES you!!{x", ch, NULL, victim, TO_VICT);
 
                 if (IS_NPC(victim))
                         sprintf(msg, "%s's severed head rolls around in front of you.",
@@ -4988,7 +4988,7 @@ void do_decapitate (CHAR_DATA *ch, char *argument)
                                 victim->name);
 
                 act (msg, ch, NULL, NULL, TO_ROOM);
-                arena_commentary("$n decapitates $N!", ch, victim);
+                arena_commentary("$c decapitates $N!", ch, victim);
 
                 vnum = OBJ_VNUM_SEVERED_HEAD;
 


### PR DESCRIPTION
In act strings, `$n` doesn't capitalize an actor's name, `$c` does.
`$c` should be used at the start of an act string, as most mobs will
have descriptions such as `a mob`, `the mob`, which should be
capitalized.

The MUD does something slightly annoying: it forces the first byte of
an act string to a capital. It is compensating for some old code,
perhaps. This behaviour allows the wrong anchor to be used everywhere.

Later, when colour escapes were added to start of act strings, the
capitalisation hack doesn't apply, and we don't capitalize the visible
text.

Fix-up some of these errors. Can't quite face changing it everywhere!