### PR TITLE
teacher fixes

### DIFF
--- a/server/area/crystal.are
+++ b/server/area/crystal.are
@@ -58,6 +58,7 @@ He looks travel weary and tired but happy to help.
 & 15 'teacher base'
 & 75 'defense knowledge'
 & 75 'inner force'
+& 75 'archery knowledge'
 #10004
 Baaz Draconian robed~
 Baaz Draconian~

--- a/server/area/helpfile.are
+++ b/server/area/helpfile.are
@@ -5201,14 +5201,14 @@ Level 10
 All your masters are in Midgaard.
 
 Level 15
-Brawler   .   .   A wandering Ranger patrols a lake (defence only).
+Brawler   .   .   A wandering Ranger patrols a lake (defence, inner force only).
 Cleric    .   .   Near Solace a fair maiden sings a beautiful song.
 Mage  .   .   .   A warrior Mage residing over the guards in Ofcol.
 Psionic   .   .   In a small cottage overlooking a river.
 Shapeshifter  .   None.
 Thief .   .   .   In an Olive Grove, a leader of Cut-throats.
 Warrior   .   .   A warrior Mage residing over the guards in Ofcol.
-Ranger    .   .   Shop around.
+Ranger    .   .   A wandering Ranger patrols a lake (archery only)
 
 Level 20
 Seek trainers for all classes in Kerofk.
@@ -5223,11 +5223,11 @@ Level 28
 Psionic   .   .   Hidden in a circle of trees in the middle of water.
 Shapeshifter  .   A flying island over a vast sea - seek the leader of birdmen.
 Brawler   .   .   Seek your inner demon - for your trainer shall be near.
-Ranger    .   .   Shop around.
 
 Level 30
 Warrior   .   .   A knight up a chain (lore etc... only)
 Bard  .   .   .   Seek a sullen bard, drowning his sorrows in an Inn.
+Ranger            A ranger of course, sitting at a table
 
 Level 35
 Seek all trainers in the town of Anon.

--- a/server/area/kerofk.are
+++ b/server/area/kerofk.are
@@ -249,7 +249,8 @@ an expert in her field.
 0 0
 8 8 2
 & 20 'teacher base'
-& 85 'herb lore'
+& 80 'herb lore'
+& 80 'archery knowledge'
 & 30 'bard base'
 #30216
 lawyer~
@@ -356,7 +357,7 @@ Jenk~
 Jenk is here, ready to sell you anything!
 ~
 Jenk is a lowdown no good shopkeeper who'll sell anything to make a
-gold!  He's corrupt, greedy, and you're kind of man!
+gold!  He's corrupt, greedy, and your kind of man!
 ~
 2|512|32768|16777216 0 -500 S
 53 0 0 6d10+590 1d8+18

--- a/server/area/midgaard.are
+++ b/server/area/midgaard.are
@@ -857,6 +857,7 @@ He seems like a man who knows many secrets.
 & 70 'thievery skills'
 & 70 'defense knowledge'
 & 70 'armed combat knowledge'
+& 70 'archery knowledge'
 & 70 'dowse'
 & 70 'forage'
 #0


### PR DESCRIPTION
None of the < 30 teachers could teach archery, have fixed up and adjusted help entry.

Was actually a level 30 ranger teacher, he teaches more than just hunting, updated help to note.