### PR TITLE
Tweaks

### DIFF
--- a/server/area/crystal.are
+++ b/server/area/crystal.are
@@ -59,6 +59,8 @@ He looks travel weary and tired but happy to help.
 & 75 'defense knowledge'
 & 75 'inner force'
 & 75 'archery knowledge'
+& 75 'dowse'
+& 75 'forage'
 #10004
 Baaz Draconian robed~
 Baaz Draconian~

--- a/server/area/draagdim.are
+++ b/server/area/draagdim.are
@@ -663,6 +663,7 @@ mpecho {dWhispered promises of power and wisdom enter your mind.{x
 & 105 'kiai'
 & 105 'spellcraft'
 & 105 'dowse'
+& 105 'forage'
 & 105 'resistance magiks'
 & 105 'musicianship'
 

--- a/server/area/freeport.are
+++ b/server/area/freeport.are
@@ -532,6 +532,7 @@ him.
 & 110 'kiai'
 & 110 'spellcraft'
 & 110 'dowse'
+& 110 'forage'
 & 110 'musicianship'
 & 110 'resistance magiks'
 #0

--- a/server/area/helpfile.are
+++ b/server/area/helpfile.are
@@ -4794,12 +4794,12 @@ second attack           sneak                   third attack
 hide                    forage                  dowse
 dodge                   disarm                  parry
 find traps              disarm traps            grip
-feint                   shoot                   snap shot
+feint                   shoot                   snapshot
 
 True rangers (those that don't change to barbarians or bards) may also
 learn these skills after level 30:
 
-gather                   thrust                  second shot
+gather                  thrust                  second shot
 barkskin                third shot              hunt
 detect hidden           infravision             snare
 dual                    enhanced hit            classify
@@ -5902,7 +5902,7 @@ high damage.  Rangers who have practised ACCURACY can also increase the
 amount of damage inflicted by each shot they land.
 ~
 
-0 'SNAP SHOT'~
+0 'SNAP SHOT' 'SNAPSHOT'~
 Syntax: snapshot
 
 During combat, if they have a bow ready, skilled Rangers can get away a 

--- a/server/area/kerofk.are
+++ b/server/area/kerofk.are
@@ -251,7 +251,10 @@ an expert in her field.
 & 20 'teacher base'
 & 80 'herb lore'
 & 80 'archery knowledge'
+& 80 'dowse'
+& 80 'forage'
 & 30 'bard base'
+& 30 'ranger base'
 #30216
 lawyer~
 the Lawyer~
@@ -450,10 +453,13 @@ eyebrow to you...shall we have a go at it?
 & 80 'defense knowledge'
 & 80 'archery knowledge'
 & 80 'inner force'
+& 80 'dowse'
+& 80 'forage'
 & 30 'knight base'
 & 30 'thug base'
 & 30 'warrior base'
 & 30 'barbarian base'
+& 30 'ranger base'
 #30230
 beggar~
 the Beggar~

--- a/server/area/krondor.are
+++ b/server/area/krondor.are
@@ -929,6 +929,8 @@ endif
 & 100 'poison arts'
 & 100 'hunting arts'
 & 100 'martial arts'
+& 100 'dowse'
+& 100 'forage'
 & 100 'knowledge'
 & 30 'thief base'
 & 30 'ninja base'

--- a/server/area/school.are
+++ b/server/area/school.are
@@ -53,6 +53,9 @@ knowledge.
 & 60 'mana control disciplines'
 & 60 'morphing knowledge'
 & 60 'archery knowledge'
+& 60 'spellcraft'
+& 60 'ranger base'
+& 60 'dowse'
 
 #3701
 manservant~

--- a/server/area/tcwn.are
+++ b/server/area/tcwn.are
@@ -293,6 +293,8 @@ The Warrior Guildmaster stares at you grimly.
 & 95 'knowledge'
 & 95 'metal working techniques'
 & 95 'riding techniques'
+& 95 'dowse'
+& 95 'forage'
 & 30 'knight base'
 & 30 'barbarian base'
 & 30 'ranger base'

--- a/server/area/wyvern.are
+++ b/server/area/wyvern.are
@@ -217,6 +217,8 @@ The years of wandering have left the ranger hardened and strong.
 & 85 'hunting arts'
 & 85 'herb lore'
 & 85 'archery knowledge'
+& 85 'dowse'
+& 85 'forage'
 #1707
 ranger leader~
 a ranger leader~

--- a/server/src/fight.c
+++ b/server/src/fight.c
@@ -5979,16 +5979,28 @@ void do_shoot (CHAR_DATA *ch, char *argument)
         WAIT_STATE(ch, PULSE_VIOLENCE);
         send_to_char("{WYou take aim and let loose!{x\n\r", ch);
 
-        if (number_percent () < ch->pcdata->learned[gsn_shoot])
+        if ( ( number_percent () < ch->pcdata->learned[gsn_shoot] )
+        ||   ( IS_AFFECTED(victim, AFF_HOLD) ) )
         {
+                /* Shot check won't fail if victim is trapped/snared - Owl 11/6/22 */
+
                 arena_commentary("$n shoots a volley of missiles at $N.", ch, victim);
 
                 num = 1;
 
-                if (number_percent() < ch->pcdata->learned[gsn_second_shot])
+                if ( ( number_percent() < ch->pcdata->learned[gsn_second_shot] ) 
+                ||    ( ( IS_AFFECTED(victim, AFF_HOLD) ) 
+                     && ( ch->pcdata->learned[gsn_second_shot]) ) )
+                {
                         num++;
-                if (number_percent() < ch->pcdata->learned[gsn_third_shot])
+                }
+
+                if ( ( number_percent() < ch->pcdata->learned[gsn_third_shot] ) 
+                ||   ( ( IS_AFFECTED(victim, AFF_HOLD) ) 
+                     && ( ch->pcdata->learned[gsn_third_shot]) ) )
+                {
                         num++;
+                }
 
                 for (i = 0; i < num; i++)
                 {

--- a/server/src/fight.c
+++ b/server/src/fight.c
@@ -6066,7 +6066,7 @@ void do_snap_shot (CHAR_DATA *ch, char *argument)
         equip_char(ch, obj, WEAR_WIELD);
         WAIT_STATE(ch, 2 * PULSE_VIOLENCE);
 
-        send_to_char("{WYou quickly grab you bow fire off a shot!{x\n\r", ch);
+        send_to_char("{WYou quickly grab your bow and fire off a shot!{x\n\r", ch);
 
         if (number_percent () < 50 + ch->pcdata->learned[gsn_snap_shot] / 2)
         {


### PR DESCRIPTION
- Ranger 'shoot' skill now has synergies with 'snare'.  Basically if a mob is trapped/snared you won't have a shoot skill check conducted (though the usual AC checks in one_hit() will still apply)

- Have made sure all ranger trainers can train dowse and forage