### PR TITLE
Player directory startup check and bug reporting fix

### DIFF
--- a/server/src/comm.c
+++ b/server/src/comm.c
@@ -45,6 +45,7 @@
 #include <sys/stat.h>
 #include <sys/time.h>
 #include <ctype.h>
+#include <dirent.h>
 #include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -165,6 +166,7 @@ bool    process_output          args((DESCRIPTOR_DATA *d, bool fPrompt));
 void    read_from_buffer        args((DESCRIPTOR_DATA *d));
 void    stop_idling             args((CHAR_DATA *ch));
 void    bust_a_prompt           args((DESCRIPTOR_DATA *d));
+void    assert_directory_exists args((const char *path));
 
 
 int main(int argc, char **argv)
@@ -214,6 +216,12 @@ int main(int argc, char **argv)
                         exit(1);
                 }
         }
+
+
+        /*
+         * Check certain directories exist. This helps to avoid surprising errors once the server is running.
+         */
+        assert_directory_exists(PLAYER_DIR);
 
         /*
          * Run the game.
@@ -2167,12 +2175,12 @@ void nanny (DESCRIPTOR_DATA *d, char *argument)
                          * Shade 17.6.22
                          *
                          * Make it easier for starting characters; will edit here in the level 0 code not in clear_char
-                         * 
+                         *
                          * Give them a few of each pracs to get going, make starting hits 50 not 20
                          */
 
-                        
-                        ch->max_hit = 50;                        
+
+                        ch->max_hit = 50;
                         ch->hit = ch->max_hit;
 
                         ch->pcdata->str_prac = 2;
@@ -3752,10 +3760,24 @@ void send_paragraph_to_char (char* text, CHAR_DATA* ch, unsigned int indent)
                 buf[pos++] = '\r';
                 i += k;
         }
-        
+
         buf[pos] = '\0';
         send_to_char (buf, ch);
 }
 
+void assert_directory_exists(const char *path)
+{
+        DIR * dir;
+        char buf[MAX_STRING_LENGTH];
+
+        dir = opendir(path);
+        if (dir) {
+                closedir(dir);
+        } else {
+                sprintf(buf, "Required directory does not exist or cannot be opened: %s", path);
+                bug(buf, MAX_STRING_LENGTH);
+                exit(1);
+        }
+}
 
 /* EOF comm.c */

--- a/server/src/db.c
+++ b/server/src/db.c
@@ -4278,15 +4278,15 @@ void bug( const char *str, int param )
         sprintf( buf + strlen( buf ), str, param );
         log_string( buf );
 
-        fclose( fpReserve );
+        /* We used to close the fpReserve file handle here then reopen it after writing to the bug file,
+           but this can cause the wrong error to be logged (and a hard crash to occur) under some conditions.
+           We probably don't need to ever reserve a file handle on a modern server.
+           It is better to just assume we will not hit open file limits rather than risk exploding... */
         if ( ( fp = fopen( BUG_FILE, "a" ) ) )
         {
                 fprintf( fp, "%s\n", buf );
                 fclose( fp );
         }
-        fpReserve = fopen( NULL_FILE, "r" );
-
-        return;
 }
 
 
@@ -4454,9 +4454,9 @@ void load_games( FILE *fp )
 	    pGame->bankroll		= fread_number( fp, &stat );
 	    pGame->max_wait		= fread_number( fp, &stat );
 	    pGame->cheat		= fread_number( fp, &stat );
-            
+
             sprintf(buf, "[croupier] %s (vnum %d).",
-                        pMobIndex->short_descr, 
+                        pMobIndex->short_descr,
                         pMobIndex->vnum
             );
             log_string(buf);


### PR DESCRIPTION
## Check the player directory exists at server startup.

Avoids weird issues when pfiles are saved and player directory does
not exist (e.g. the skeleton was not copied across during the initial
setup).

## Avoid crashing when recording bug information

In some situations (e.g. the player/ directory is not writable when
attempting to save a pfile) the server will report the wrong error and
then crash due to encountering another error during error handling.

This error relates to manipulating the "reserved file handle" fpReserve.
fpReserve may already be closed and we attempt to double-close it.

Rather than trying to cope with fights over fpReserve, just remove this
manipulation from the bug function. We are unlikely to ever hit OS
limits these days.
