### PR TITLE
Colours tweaks

### DIFF
--- a/server/src/act_info.c
+++ b/server/src/act_info.c
@@ -4131,8 +4131,8 @@ void do_prompt( CHAR_DATA *ch, char *argument )
                 strcat (buf, "<<{G%h/%H{x hits {C%m/%M{x mana {Y%v/%V{x move [{W%z{x]> ");
         else
         {
-                if ( strlen( argument ) > 100 )
-                        argument[100] = '\0';
+                if ( strlen( argument ) > MAX_PROMPT_LENGTH )
+                        argument[MAX_PROMPT_LENGTH] = '\0';
                 smash_tilde( argument );
                 strcat( buf, argument );
         }

--- a/server/src/act_info.c
+++ b/server/src/act_info.c
@@ -3628,8 +3628,8 @@ void do_ansi( CHAR_DATA *ch, char *argument )
                         send_to_char( buf, ch );
                 }
                 
-                send_to_char( "\n\rTo toggle colour, type 'COLOUR'. Text/numerical colour codes can be viewed with 'HELP COLOURCODES'.\n\r"
-                             "Type 'HELP COLOUR,' 'HELP COLOUR2,' and 'HELP COLOUR3,' and 'HELP ANSI' for more information.\n\r", ch );
+                send_to_char( "\n\rTo toggle colour, type 'COLOUR'. Colour codes can be viewed with 'HELP COLOURCODES'.\n\r"
+                             "See 'HELP COLOUR,' 'HELP COLOUR2,' 'HELP COLOUR3,' and 'HELP ANSI' for more information.\n\r", ch );
                 return;
         }
 

--- a/server/src/merc.h
+++ b/server/src/merc.h
@@ -267,6 +267,7 @@ bool    has_tranquility ( CHAR_DATA *ch );
 #define MAX_LEVEL                        106
 #define MAX_TRADE                          5
 #define MAX_DAMAGE                      6000    /* Increased from 3k->6k for chaos blast --Owl 2/3/22 */
+#define MAX_PROMPT_LENGTH                200    /* Was defined locally, thought better as global -- Owl 24/7/22 */
 #define FULL_AIR_SUPPLY                    2    /* ticks before drowning; Gez */
 
 #define L_IMM                       MAX_LEVEL


### PR DESCRIPTION
- New longer colour codes were making it easy to exceed current max prompt length (100 chars, raw).  Increased to 200  and made it a global value (was hidden as a raw int in a local function).