### PR TITLE
l2 gag hides misses, fixed crashing bug

### DIFF
--- a/server/area/helpfile.are
+++ b/server/area/helpfile.are
@@ -1430,8 +1430,8 @@ least damage to most damage:
        <237>graze<0>          <249>MUTILATE<0>        <160><558>RAVAGE<0>         <52><558>NULLIFY<559>                    
        <239>hit<0>            <251>DISEMBOWEL<0>      <160><558>CRIPPLE<559><0>        <52><558>BUTCHER<559>             
        <240>injure<0>         <253>EVISCERATE<0>      <124><558>BRUTALISE<559><0>      <52><558>LIQUIDATE<559>                                   
-       <241>wound<0>          <255>MASSACRE<0>        <124><558>VAPOURISE<559><0>      <52>SLAUGHTER<0>                       
-       <242>maul<0>           <196>DEMOLISH<0>        <124><558>ATOMIZE<559><0>        <52>EXTIRPATE<0>                        
+       <241>wound<0>          <255>MASSACRE<0>        <124><558>VAPOURISE<559><0>      <52>S L A U G H T E R<0>                       
+       <242>maul<0>           <196>DEMOLISH<0>        <124><558>ATOMIZE<559><0>        <352><160>E X T I R P A T E<0>                        
        <243>decimate<0>       <196>DEVASTATE<0>       <88><558>ELIMINATE<559><0>      <352><196>P A R T I C L I Z E<0>       
 ~
 

--- a/server/src/act_comm.c
+++ b/server/src/act_comm.c
@@ -1403,7 +1403,7 @@ void do_group( CHAR_DATA *ch, char *argument )
         char       buf [ MAX_STRING_LENGTH ];
         char       buf1 [ MAX_INPUT_LENGTH  ];
         char       arg [ MAX_INPUT_LENGTH  ];
-        int            npc_count;
+        int        npc_count;
 
         one_argument( argument, arg );
 
@@ -1615,7 +1615,7 @@ void do_group_leader( CHAR_DATA *ch, char *argument)
         if (ch->pcdata->group_leader)
         {
                 if (ch->pcdata->group_leader == ch)
-                        send_to_char("You are genius!\n\r", ch);
+                        send_to_char("You are, genius!\n\r", ch);
                 else
                 {
                         sprintf(buf, "%s is leading the group.\n\r",

--- a/server/src/act_move.c
+++ b/server/src/act_move.c
@@ -2128,7 +2128,6 @@ void do_recall (CHAR_DATA *ch, char *argument)
                         &&   ( IS_NPC( mob ) ) )
                         {       
                                 followers_found++;
-                                /* act_move ("$n disappears.", mob, NULL, NULL, TO_ROOM); */
                                 char_from_room(mob);
                                 char_to_room(mob, location);
                                 act_move("$n appears suddenly.", mob, NULL, NULL, TO_ROOM);

--- a/server/src/const.c
+++ b/server/src/const.c
@@ -2705,14 +2705,14 @@ const struct skill_type skill_table [MAX_SKILL] =
                 "detect good", &gsn_detect_good,
                 TYPE_INT, TAR_CHAR_SELF, POS_STANDING,
                 spell_detect_good, 5, 12,
-                "", "The yellow in your vision disappears."
+                "", "<228>The yellow in your vision disappears.<0>"
         },
 
         {
                 "detect evil", &gsn_detect_evil,
                 TYPE_INT, TAR_CHAR_SELF, POS_STANDING,
                 spell_detect_evil, 5, 12,
-                "", "The red in your vision disappears."
+                "", "<124>The red in your vision disappears.<0>"
         },
 
         {
@@ -2740,7 +2740,7 @@ const struct skill_type skill_table [MAX_SKILL] =
                 "detect magic", &gsn_detect_magic,
                 TYPE_INT, TAR_CHAR_SELF, POS_STANDING,
                 spell_detect_magic, 5, 12,
-                "", "The blue in your vision disappears."
+                "", "<27>The blue in your vision disappears.<0>"
         },
 
         {

--- a/server/src/fight.c
+++ b/server/src/fight.c
@@ -2656,7 +2656,24 @@ void dam_message (CHAR_DATA *ch, CHAR_DATA *victim, int dam, int dt, bool poison
 
         if (dt == TYPE_HIT)
         {
-                sprintf(buf1, "You %s $N%c",       vs, punct);
+                /* Combat gagging level 2 now gags 'misses' -- Owl */
+
+                if ( ( ( ch->gag == 2 )
+                    && ( dam > 0 ) ) )
+                {
+                        sprintf(buf1, "You %s $N%c",       vs, punct);
+                }
+                else if ( dam > 0 )
+                {
+                        sprintf(buf1, "You %s $N%c",       vs, punct);
+                }
+                else if ( ch->gag < 2 )
+                {
+                        sprintf(buf1, "You %s $N%c",       vs, punct);
+                }
+                else {
+                       sprintf(buf1, "\0");  
+                }
 
                 /*
                  * Shade 10.5.2022 - make you getting hit stand out more, help when a lot of room spam
@@ -3968,6 +3985,19 @@ void do_rescue (CHAR_DATA *ch, char *argument)
 
         char arg [ MAX_INPUT_LENGTH ];
 
+        if ( IS_NPC(ch)
+        &&  ( ch->master) )
+        {
+                /* 
+                 * Ordering an NPC you're grouped with to rescue you disconnects you and often crashes the MUD.
+                 * be warned if you decide you want charmed/grouped mobs to be able to rescue players you will
+                 * need to fix this issue, not just delete this check. Note the issue does not exist if the charmed 
+                 * NPC is not grouped with you. -- Owl 24/7/22
+                 */ 
+                
+                return;
+        }
+
         if (!IS_NPC(ch) && !CAN_DO(ch, gsn_rescue))
         {
                 send_to_char("You'd better leave the heroic acts to warriors.\n\r", ch);
@@ -3976,7 +4006,7 @@ void do_rescue (CHAR_DATA *ch, char *argument)
 
         if (is_affected(ch, gsn_berserk))
         {
-                send_to_char("You cant rescue anyone, you're BERSERK!\n\r", ch);
+                send_to_char("You can't rescue anyone, you're BERSERK!\n\r", ch);
                 return;
         }
 
@@ -6707,13 +6737,13 @@ char *get_damage_string( int damage_value, bool is_singular )
         }
         else if (damage_value <= 5000)   
         {
-                vs = "<0><52>-=+<<##SLAUGHTER<52>##>+=-<0>"; 
-                vp = "<0><52>-=+<<##SLAUGHTERS<52>##>+=-<0>"; 
+                vs = "<0><52>-=+<<##S L A U G H T E R<52>##>+=-<0>"; 
+                vp = "<0><52>-=+<<##S L A U G H T E R S<52>##>+=-<0>"; 
         }
         else if (damage_value <= 5500)   
         {
-                vs = "<0><52>-=+*<<(|[ EXTIRPATE ]|)>*+=-<0>"; 
-                vp = "<0><52>-=+*<<(|[ EXTIRPATES ]|)>*+=-<0>"; 
+                vs = "<0><52>-=+*<<(|[ <352><160>E X T I R P A T E<0><52> ]|)>*+=-<0>"; 
+                vp = "<0><52>-=+*<<(|[ <352><160>E X T I R P A T E S<0><52> ]|)>*+=-<0>"; 
         }
         else
         {


### PR DESCRIPTION
- 'Heavy' gagging now hides your misses
- Ordering a grouped NPC to rescue you no longer crashes the MUD
- Minor text tweaks and tidy-ups