### PR TITLE
Increase bitvalues

### DIFF
--- a/server/area/bastion.are
+++ b/server/area/bastion.are
@@ -412,7 +412,7 @@ The bastion's weaponsmith is intently sharpening a long sword.
 ~
 The weaponsmith pauses long enough to inspect the blade he is sharpening
 before continuing with his task. His muscles bunch and ripple as he
-skillfully runs the whetstone down the blade. He seems to be too intent
+skilfully runs the whetstone down the blade. He seems to be too intent
 upon his work to notice you have arrived.
 ~
 2|64 8|32|512 0 S

--- a/server/area/demondium.are
+++ b/server/area/demondium.are
@@ -1908,7 +1908,7 @@ cursed ring~
 an ancient cursed ring~
 A small black ring hums quietly to itself.~
 ~
-9 1|2|16 1|2
+9 1|2|16|2305843009213693952 1|2
 0~ 1~ 6~ 11~
 5 0 0
 A
@@ -2304,7 +2304,7 @@ cursed spike~
 an ancient cursed spike~
 An ancient cursed spike sits here waiting to possess someone.~
 ~
-5 16|64|128|512|2048|4096 1|8192
+5 16|64|128|512|2048|4096|2305843009213693952 1|8192
 0~ 15~ 21~ 11~
 5 0 0
 A
@@ -2314,7 +2314,7 @@ cursed spike~
 a old cursed spike~
 An old, but not ancient cursed spike waits to possess someone.~
 ~
-5 16|64|128|512|2048|4096 1|8192
+5 16|64|128|512|2048|4096|2305843009213693952 1|8192
 0~ 10~ 19~ 11~
 5 0 0
 A

--- a/server/area/east_of_draagdim.are
+++ b/server/area/east_of_draagdim.are
@@ -209,7 +209,7 @@ a hill giant priestess~
 Thick green robes cover a tall hill giant.
 ~
 Tall but still quite solid, the hill giant priestess is cunning and
-skillful in the arts of woodland magic.  She has led her small band to the
+skilful in the arts of woodland magic.  She has led her small band to the
 road to waylay travellers who stray too far east.
 ~
 2|32 8|65536|8388608 -700 S

--- a/server/area/highland.are
+++ b/server/area/highland.are
@@ -443,7 +443,7 @@ A
 #11514
 potion lady~
 potion of the Lady~
-a potion stands here.~
+A potion is here.~
 ~
 10 128 1
 13~ curse~ cure blindness~ cure poison~

--- a/server/area/limbo.are
+++ b/server/area/limbo.are
@@ -1382,7 +1382,7 @@ this room is a HUGE big screen tv. Sitting on the other side of this room
 is a small compact PC. Sitting next to the PC is a donut robot(tm)
 constantly making donuts.
 ~
-0 4|8|512|1024|2048|8192|16384 0
+0 4|8|512|1024|2048|8192|16384|9223372036854775808 0
 S
 #77
 Inside a bottle~

--- a/server/area/mtdoom2.are
+++ b/server/area/mtdoom2.are
@@ -676,7 +676,7 @@ krothgar helm~
 the cursed helm of Lord Krothgar~
 The cursed helm of Lord Krothgar is here.~
 ~
-9 2|16|64|128|512|2048|4096 1|16
+9 2|16|64|128|512|2048|4096|2305843009213693952 1|16
 0~ 0~ 0~ 0~
 5 0 0
 A

--- a/server/area/pyramid.are
+++ b/server/area/pyramid.are
@@ -8,8 +8,8 @@ asp snake~
 A horrible asp~
 A small, poisonous asp slithers over your feet.
 ~
-The asp is a small, smooth-scaled snake the color of worn pottery.
-The poison bite of this snake has felled many a mighty pharoah.
+The asp is a small, smooth-scaled snake the colour of worn pottery.
+The poison bite of this snake has felled many a mighty pharaoh.
 ~
 1|32|64 0 0 S
 5 14 8 5d5+50 1d6+1
@@ -21,7 +21,7 @@ A hooded cobra snake~
 A cobra snake rears up and opens its fearsome hood.
 ~
 The cobra snake waves back and forth before you, its hood displaying brilliant
-colors designed to serve notice to its prey that it is about to strike.
+colours designed to serve notice to its prey that it is about to strike.
 ~
 1|32|64 0 0 S
 7 13 7 7d7+70 2d4+2
@@ -45,8 +45,8 @@ A pyramid watcher~
 The pyramid watcher protects the tombs from intruders.
 ~
 The pyramid watcher has made a pledge to destroy any would-be looters of
-the tombs of the pharoahs.  He is clad from head to foot in utilitarian
-sand-colored clothing.
+the tombs of the pharaohs.  He is clad from head to foot in utilitarian
+sand-coloured clothing.
 ~
 1|2 0 250 S
 8 12 5 8d8+80 2d6+2
@@ -66,9 +66,9 @@ The thief brushes against you briefly, then slinks back into the shadows.
 #2605
 ali baba thief~
 Ali Baba~
-Ali Baba is here, hunting for the pharoah's tomb.
+Ali Baba is here, hunting for the pharaoh's tomb.
 ~
-You see a tall, full-bearded man with a mischevious glint in his eye.  Ali Baba
+You see a tall, full-bearded man with a mischievous glint in his eye.  Ali Baba
 has made his life from stealing things from others, including many items stolen
 recently from under the nose of the hapless guardians of this pyramid.  Someday
 he might get caught, but not today...
@@ -202,7 +202,7 @@ A mighty androsphinx tosses its lion-like mane.
 ~
 The mighty androsphinx is a huge creature, with the body of a lion whose
 face  is quite man-like, perhaps even handsome, and a massive pair of feathered
-wings.  Tales are told of pharoahs that were rendered permanently deaf by the
+wings.  Tales are told of pharaohs that were rendered permanently deaf by the
 mighty roar of this sphinx.
 ~
 1|2 8 400 S
@@ -227,7 +227,7 @@ advised many rulers.
 #2617
 ramses mummy~
 Ramses the Damned~
-You have awakened the mighty servant to the pharoahs, Ramses.
+You have awakened the mighty servant to the pharaohs, Ramses.
 ~
 As your light spills over his face and body, you can see his features begin
 to fill out, swell, and harden, until an apparently healthy man stands before
@@ -247,7 +247,7 @@ his chest not even moving to breathe.
 #2600
 egyptian mace~
 an egyptian mace~
-A hierogylph-engraved mace has been left here.~
+A hieroglyph-engraved mace has been left here.~
 ~
 5 0 8193
 0~ 0~ 0~ 7~
@@ -258,15 +258,15 @@ The mace is formed from solid brass, and engraved in strange hieroglyphs.
 ~
 #2601
 sand robes~
-sand-colored robes~
-Sand-colored robes lie here.~
+sand-coloured robes~
+Sand-coloured robes lie here.~
 ~
 9 0 1025
 4~ 0~ 0~ 0~
 5 500 40
 E
 sand robes~
-The robes are colored a sandy off-white, and are in fact caked and covered
+The robes are coloured a sandy off-white, and are in fact caked and covered
 with sand as well.  You don't seem to be able to remove all of the sand, no
 matter how much you try.
 ~
@@ -396,11 +396,11 @@ A mighty stone sarcophagus lies in the center of the tomb.~
 5000 5000 5000
 E
 stone sarcophagus~
-The sarcophagus is engraved on the sides with the images of pharoahs,
+The sarcophagus is engraved on the sides with the images of pharaohs,
 great wars fought long ago, mighty pyramids being constructed...
 
 A raised image atop the sarcophagus is formed in the visage of one of
-the mighty pharoahs, painted in gold and studded with precious gems.
+the mighty pharaohs, painted in gold and studded with precious gems.
 
 You see a small keyhole in the side of the sarcophagus.
 ~
@@ -541,7 +541,7 @@ curse mummy~
 the curse of the mummy~
 Some fortunate soul has escaped the mummy's curse, for now.~
 ~
-13 16|64|128|4096 16385
+13 16|64|128|4096|2305843009213693952 16385
 0~ 0~ 0~ 0~
 1 500 50
 A
@@ -556,8 +556,8 @@ A
 14 -100
 E
 curse mummy~
-Rumor has it that whomever disturbs the grave of the mummy shall be
-cursed for all eternity, and that the descendents of that person shall
+Rumour has it that whomever disturbs the grave of the mummy shall be
+cursed for all eternity, and that the descendants of that person shall
 likewise be cursed for ten generations to follow.
 ~
 #2621
@@ -632,8 +632,8 @@ brilliant blazing light of the sun.
 ~
 #2625
 sandy ring~
-a sandy-colored ring~
-A small sandy-colored ring has been carelessly dropped here.~
+a sandy-coloured ring~
+A small sandy-coloured ring has been carelessly dropped here.~
 ~
 9 2|64 3
 8~ 0~ 0~ 0~
@@ -644,7 +644,7 @@ A
 12 50
 E
 sandy ring~
-The ring is small, smooth, sandy-colored and unremarkable, save that
+The ring is small, smooth, sandy-coloured and unremarkable, save that
 it gives off a continuous low humming noise that tickles your fingertips.
 ~
 #2626
@@ -714,7 +714,7 @@ Across the hot burning sands you see a small oasis and some tents.
 0 -1 5056
 E
 pyramid~
-The massive pyramid rises out of the sand, a monument to long-dead pharoahs.
+The massive pyramid rises out of the sand, a monument to long-dead pharaohs.
 ~
 S
 #2601
@@ -920,7 +920,7 @@ S
 #2607
 Climbing the Great Pyramid~
    Here the elements have carved away at the sides of the pyramid quite a
-bit.  You aren't so sure of your footing anymore...
+bit.  You aren't so sure of your footing any more...
 
 Suddenly the wind picks up, and you lose your balance!
 You tumble down the side of the pyramid, and fall to your death!
@@ -1353,7 +1353,7 @@ S
 #2626
 A Demolished Tomb~
   This tomb has been utterly destroyed by thieves and looters in search of
-the treasures of the pharoahs.  Nothing of interest remains in this room,
+the treasures of the pharaohs.  Nothing of interest remains in this room,
 except a large stone coffin that leans against the western wall.
 ~
 26 8 0
@@ -1370,14 +1370,14 @@ coffin lid~
 E
 coffin lid~
 The coffin is sculpted into the form of a man, standing several heads above
-you, and clad in the garments of pharoahs.  It has apparently been untouched
+you, and clad in the garments of pharaohs.  It has apparently been untouched
 by the ravages of time and the activities of looters.  Several markings on the
 side indicate spots where unsuccessful attempts were made to open the coffin.
 
 You can't see any way to open it.
 ~
 E
-man garments pharoah~
+man garments pharaoh~
 As you look closer at the figure sculpted into the stone coffin you notice a
 small marking carved into its chest.  It looks like a scarab or small beetle
 would fit into the small space, if properly sized.
@@ -1496,8 +1496,8 @@ tomb~
 E
 pedestal writings~
 The writings are covered in sand and worn nearly away by the passage
-of time: 'I am Ramses the Damned, once counselor and aide to the mightiest
-of pharoahs and queens of this land.  Much time has passed since I last
+of time: 'I am Ramses the Damned, once counsellor and aide to the mightiest
+of pharaohs and queens of this land.  Much time has passed since I last
 walked the earth.  Disturb my rest at your peril.'
 ~
 S
@@ -1734,11 +1734,11 @@ The Tomb Entrance~
    You are in a small, dark chamber that has stood undisturbed for
 many years.  To the north stands a massive stone tomb, which is
 covered in hieroglyphics and gold-lined carvings that mark it as the
-final resting place of the mighty pharoahs of this land.
+final resting place of the mighty pharaohs of this land.
 ~
 26 13 0
 D0
-You see the tomb of the pharoahs.
+You see the tomb of the pharaohs.
 ~
 tomb~
 1 -1 2645
@@ -1755,14 +1755,14 @@ which encloses it.  It is covered in small hieroglyphics.
 E
 hieroglyphics carvings~
 The markings indicate that this tomb is indeed the tomb of the greatest
-pharoahs of the ancient civilization that built this massive pyramid.
+pharaohs of the ancient civilization that built this massive pyramid.
 ~
 S
 #2645
-The Tomb of the Pharoahs~
-   Great golden sarcophogai line the walls of this massive tomb.  It has
+The Tomb of the Pharaohs~
+   Great golden sarcophagi line the walls of this massive tomb.  It has
 withstood the passage of time intact, untouched by the hands of thieves
-and looters.  The treasures taken by the pharoahs to their graves still
+and looters.  The treasures taken by the pharaohs to their graves still
 lie before your feet.
 ~
 26 9 0
@@ -1880,7 +1880,7 @@ You see an arched hall.
 0 -1 2649
 E
 rug rugs tapestry tapestries~
-The rugs and tapestries are very fine and worn with age, their colors
+The rugs and tapestries are very fine and worn with age, their colours
 now faded.  They depict scenes of life in an ancient desert city.
 ~
 E
@@ -2164,9 +2164,9 @@ S
  D 0 2630 0 1     from the inside
  D 0 2631 5 1     Close the stone into the tomb of Ramses from above
  D 0 2632 4 1     from below
- D 0 2643 5 1     Close the floor into the tomb of the pharoahs
- D 0 2644 4 1     Close the ceiling out of the tomb of the pharoahs
- D 0 2644 0 1     Close the tomb of the pharoahs from the outside
+ D 0 2643 5 1     Close the floor into the tomb of the pharaohs
+ D 0 2644 4 1     Close the ceiling out of the tomb of the pharaohs
+ D 0 2644 0 1     Close the tomb of the pharaohs from the outside
  D 0 2645 2 1     from the inside
  D 0 2658 2 2     LOCK the entrance to the hole in the sand
 * it's a one-way door so we don't need to do it from the inside
@@ -2244,7 +2244,7 @@ S
 * second one, the first one will be loaded sans key on the next reset.
 * Of course, this won't really FORCE the previous players to kill both, but
 * it is more balanced than always fighting only the first caraytid.
-* And also the treasure of the pharoahs
+* And also the treasure of the pharaohs
  O 0 2610 0 2645    The stone sarcophagus
  P 0 2611 0 2610    Dust
  P 0 2612 0 2610    The scarab (key to the coffin lid in room #26)

--- a/server/area/vampcat.are
+++ b/server/area/vampcat.are
@@ -560,7 +560,7 @@ a Wamphyri Warrior~
 A large creature made of metamorphic vampire flesh floats here, insensate.
 ~
 A Wamphyri Warrior is basically an undead version of a flesh golem, fashioned by
-the skillful use of vampire magiks, alchemy and undead flesh. This one stands a
+the skilful use of vampire magiks, alchemy and undead flesh. This one stands a
 full 10 feet tall and is as yet not fully formed, you can only imagine how much
 more intimidating it would appear out of the vat and heavily armoured, as it is
 its sharp fangs dripping with noxious Wamphyri poison gives you pause for thought.

--- a/server/area/vampcat4.are
+++ b/server/area/vampcat4.are
@@ -1626,7 +1626,7 @@ A
 18 15
 E
 obsidian dagger~
-The dagger blade has been skillfully flaked from the volcanic glass,
+The dagger blade has been skilfully flaked from the volcanic glass,
 resulting in a deadly sharp cutting edge.~
 #25630
 cloak concealment~

--- a/server/src/act_info.c
+++ b/server/src/act_info.c
@@ -175,7 +175,7 @@ char *format_obj_to_char( OBJ_DATA *obj, CHAR_DATA *ch, bool fShort )
                 strcat( buf, "<15>(Imbued)<0> " );
 
         if (IS_OBJ_STAT(obj, ITEM_EGO) && IS_SET(obj->ego_flags, EGO_ITEM_CHAINED))
-                strcat( buf, "{W(Chained){x " );
+                strcat( buf, "<159>(Chained)<0> " );
         
         if (IS_OBJ_STAT(obj, ITEM_EGO) && IS_SET(obj->ego_flags, EGO_ITEM_BALANCED))
                 strcat( buf, "<155>(Balanced)<0> " );
@@ -408,7 +408,7 @@ void show_char_to_char_0( CHAR_DATA *victim, CHAR_DATA *ch )
 
         if (IS_GOOD(victim )
             && (IS_AFFECTED(ch, AFF_DETECT_GOOD) || is_affected(ch, gsn_song_of_revelation)))
-                strcat(buf, "<226>(Yellow Aura)<0> "   );
+                strcat(buf, "<190>(Yellow Aura)<0> "   );
 
         if (IS_AFFECTED(victim, AFF_SANCTUARY )   )
                 strcat(buf, "<15>(White Aura)<0> " );

--- a/server/src/act_obj.c
+++ b/server/src/act_obj.c
@@ -580,6 +580,12 @@ void do_drop (CHAR_DATA *ch, char *argument)
                 return;
         }
 
+        if (IS_SET(ch->in_room->room_flags, ROOM_NO_DROP))
+	{
+	      send_to_char ("A powerful enchantment prevents you from dropping anything here.\n\r", ch);
+	      return;
+	}
+
         if (is_number(arg))
         {
                 /* 'drop NNNN coins' */

--- a/server/src/act_wiz.c
+++ b/server/src/act_wiz.c
@@ -649,22 +649,23 @@ void do_goto( CHAR_DATA *ch, char *argument )
 
 void do_rstat( CHAR_DATA *ch, char *argument )
 {
-        OBJ_DATA        *obj;
-        CHAR_DATA       *rch;
-        ROOM_INDEX_DATA *location;
-        char             buf  [ MAX_STRING_LENGTH ];
-        char             buf1 [ MAX_STRING_LENGTH ];
-        char             arg  [ MAX_INPUT_LENGTH  ];
-        int              door;
-        int              next;
-        int              chroom_cnt      = 1;
-        int              objroom_cnt     = 1;
+        OBJ_DATA                *obj;
+        CHAR_DATA               *rch;
+        ROOM_INDEX_DATA         *location;
+        char                    buf  [ MAX_STRING_LENGTH ];
+        char                    buf1 [ MAX_STRING_LENGTH ];
+        /*char                    buf2 [ MAX_STRING_LENGTH ];*/
+        char                    arg  [ MAX_INPUT_LENGTH  ];
+        int                     door;
+        unsigned long int       next;
+        int                     chroom_cnt      = 1;
+        int                     objroom_cnt     = 1;
 
         rch = get_char( ch );
 
         if ( !authorized( rch, gsn_rstat ) )
                 return;
-
+                
         one_argument( argument, arg );
         location = ( arg[0] == '\0' ) ? ch->in_room : find_location( ch, arg );
         if ( !location )
@@ -697,7 +698,7 @@ void do_rstat( CHAR_DATA *ch, char *argument )
                 location->sector_type,
                 location->light );
         strcat( buf1, buf );
-
+        
         if (location->area->area_flags)
         {
                 sprintf( buf, "Area flags (num): {W");
@@ -711,12 +712,15 @@ void do_rstat( CHAR_DATA *ch, char *argument )
 
                 strcat( buf1, buf );
 
-                for (next = 1; next <= BIT_20; next *= 2)
-                {
+                for (next = 1; next < BIT_MAX; next *= 2)
+                {      
+                        /*sprintf(buf2,"checking: %lu \r\n", next);
+                        log_string(buf2);*/
                         if (IS_SET(location->area->area_flags, next))
                         {
                                 strcat(buf1, " ");
                                 strcat(buf1, area_flag_name(next));
+                                /*log_string(buf1);*/
                         }
                 }
 
@@ -727,6 +731,8 @@ void do_rstat( CHAR_DATA *ch, char *argument )
                 strcat(buf1, "Area flags: {Rnone {x[{W0{x]\n\r");
         }
 
+        /*sprintf(buf2,"room flags: %lu \r\n", location->room_flags);
+        log_string(buf2);*/
         if (location->room_flags)
         {
                 sprintf( buf, "Room flags (num): {W");
@@ -738,14 +744,18 @@ void do_rstat( CHAR_DATA *ch, char *argument )
 
                 strcat(buf1, "Room flags (txt):{R");
 
-                for (next = 1; next <= BIT_20; next *= 2)
+                for (next = 1; next > 0 && next <= BIT_MAX; next *= 2)
                 {
+                        /*sprintf(buf2,"looping: %lu \r\n", next);
+                        log_string(buf2);*/
+
                         if (IS_SET(location->room_flags, next))
                         {
                                 strcat(buf1, " ");
                                 strcat(buf1, room_flag_name(next));
                         }
                 }
+
                 strcat(buf1, "{x\n\r");
         }
         else {
@@ -808,12 +818,7 @@ void do_rstat( CHAR_DATA *ch, char *argument )
         {
                 strcat( buf1, "{xObjects:" );
         }
-/*
-        int              chroom_cnt      = 1;
-        int              chroom_max      = 100;
-        int              objroom_cnt     = 1;
-        int              objroom_max     = 100;
-        */
+
         for ( obj = location->contents; obj; obj = obj->next_content )
         {
                 objroom_cnt++;
@@ -4835,13 +4840,15 @@ void do_rename( CHAR_DATA *ch, char *argument )
 
 void do_rset( CHAR_DATA *ch, char *argument )
 {
-        CHAR_DATA       *rch;
-        CHAR_DATA       *person;
-        ROOM_INDEX_DATA *location;
-        char             arg1 [ MAX_INPUT_LENGTH ];
-        char             arg2 [ MAX_INPUT_LENGTH ];
-        char             arg3 [ MAX_INPUT_LENGTH ];
-        int              value;
+        CHAR_DATA               *rch;
+        CHAR_DATA               *person;
+        ROOM_INDEX_DATA         *location;
+        char                    arg1 [ MAX_INPUT_LENGTH ];
+        char                    arg2 [ MAX_INPUT_LENGTH ];
+        char                    arg3 [ MAX_INPUT_LENGTH ];
+        int                     value;
+        unsigned long int       bvalue;
+        char                    *bptr;
 
         rch = get_char( ch );
 
@@ -4877,6 +4884,7 @@ void do_rset( CHAR_DATA *ch, char *argument )
                 return;
         }
         value = atoi( arg3 );
+        bvalue = strtoul(arg3, &bptr, 10);
 
         for ( person = location->people; person; person = person->next_in_room )
         {
@@ -4892,7 +4900,7 @@ void do_rset( CHAR_DATA *ch, char *argument )
          */
         if ( !str_cmp( arg2, "flags" ) )
         {
-                location->room_flags    = value;
+                location->room_flags    = bvalue;
                 return;
         }
 

--- a/server/src/comm.c
+++ b/server/src/comm.c
@@ -3667,10 +3667,8 @@ void bit_explode (CHAR_DATA *ch, char* buf, long unsigned int n)
         sprintf(buf3, "k=%lu a[k]=%lu\r\n",k, a[k]);
         log_string(buf3);
     }
-
     sprintf(buf2,"bit_explode was passed: %lu", n);
     log_string(buf2);
-
     Doesn't accept stupid values
     if (n <= 0 || n > 18446744073709551616)
         return;       */ 

--- a/server/src/db.c
+++ b/server/src/db.c
@@ -1545,6 +1545,9 @@ void load_area_special (FILE *fp)
                 else if (!str_cmp(next, "no_teleport"))
                         SET_BIT(area_last->area_flags, AREA_FLAG_NO_TELEPORT);
 
+                else if (!str_cmp(next, "no_magic"))
+                        SET_BIT(area_last->area_flags, AREA_FLAG_NO_MAGIC);
+
                 else if (!str_cmp(next, "exp_mod"))
                 {
                         num = fread_number(fp, &stat);
@@ -1753,8 +1756,8 @@ void load_objects( FILE *fp )
 {
         OBJ_INDEX_DATA *pObjIndex;
         char buf [MAX_STRING_LENGTH];
-        char buf2 [MAX_STRING_LENGTH];
-        /*char buf3 [MAX_STRING_LENGTH];*/
+        /*char buf2 [MAX_STRING_LENGTH];
+        char buf3 [MAX_STRING_LENGTH];*/
         int stat;
 
         for ( ; ; )
@@ -1802,12 +1805,12 @@ void load_objects( FILE *fp )
                 pObjIndex->item_type            = fread_number( fp, &stat );
                 pObjIndex->extra_flags          = fread_number64( fp, &stat );
 
-                if (pObjIndex->extra_flags > 4200000000)
+                /*if (pObjIndex->extra_flags > 4200000000)
                 {
                         sprintf(buf2,"%s is %lu",pObjIndex->name, pObjIndex->extra_flags);
                         log_string(buf2);
 
-                }
+                }*/
 
                 if (IS_SET(pObjIndex->extra_flags, ITEM_TRAP) )
                 {
@@ -2231,7 +2234,11 @@ void load_rooms( FILE *fp )
                 pRoomIndex->name                = fread_string( fp );
                 pRoomIndex->description         = fread_string( fp );
                 /* Area number */                 fread_number( fp, &stat );   /* Unused */
-                pRoomIndex->room_flags          = fread_number( fp, &stat );
+                pRoomIndex->room_flags          = fread_number64( fp, &stat );
+                
+                if (IS_SET(pRoomIndex->area->area_flags, AREA_FLAG_NO_MAGIC))
+                        SET_BIT(pRoomIndex->room_flags, ROOM_CONE_OF_SILENCE);
+                
                 pRoomIndex->sector_type         = fread_number( fp, &stat );
                 pRoomIndex->light               = 0;
 
@@ -3575,7 +3582,7 @@ unsigned long int fread_number64( FILE *fp, int *status )
 {
     int c;
     bool sign;
-    /*char buf [MAX_INPUT_LENGTH]; */ 
+    /*char buf [MAX_INPUT_LENGTH];*/
     unsigned long int number;
     int stat;
 

--- a/server/src/fight.c
+++ b/server/src/fight.c
@@ -4606,8 +4606,8 @@ void do_trap (CHAR_DATA *ch, char *argument)
                 AFFECT_DATA af;
 
                 arena_commentary("$n traps $N.", ch, victim);
-                act ("You skillfully snare $N in your trap!", ch, NULL, victim, TO_CHAR);
-                act ("$n skillfully snares $N in $s trap!", ch, NULL, victim, TO_ROOM);
+                act ("You skilfully snare $N in your trap!", ch, NULL, victim, TO_CHAR);
+                act ("$n skilfully snares $N in $s trap!", ch, NULL, victim, TO_ROOM);
 
                 af.type         = gsn_trap;
                 af.duration     = 5;
@@ -4716,7 +4716,7 @@ void do_snare (CHAR_DATA *ch, char *argument)
 
                 arena_commentary("$n snares $N.", ch, victim);
                 act ("$N becomes entangled in your snare!", ch, NULL, victim, TO_CHAR);
-                act ("$n skillfully entangles $N in $s snare!", ch, NULL, victim, TO_ROOM);
+                act ("$n skilfully entangles $N in $s snare!", ch, NULL, victim, TO_ROOM);
 
                 af.type         = gsn_snare;
                 af.duration     = 6;

--- a/server/src/handler.c
+++ b/server/src/handler.c
@@ -2598,6 +2598,8 @@ char *item_type_name( OBJ_DATA *obj  )
             case ITEM_WHETSTONE:        return "whetstone";
             case ITEM_CRAFT:            return "crafting";
             case ITEM_SPELLCRAFT:       return "spellcrafting";
+            case ITEM_TURRET_MODULE:    return "turret module";
+            case ITEM_FORGE:            return "forge";
         }
 
         for ( in_obj = obj; in_obj->in_obj; in_obj = in_obj->in_obj )
@@ -2674,31 +2676,46 @@ char *affect_loc_name( int location )
 
 int item_name_type( char *name )
 {
-        if ( !str_cmp( name, "light"     ) ) return ITEM_LIGHT;
-        if ( !str_cmp( name, "scroll"    ) ) return ITEM_SCROLL;
-        if ( !str_cmp( name, "wand"      ) ) return ITEM_WAND;
-        if ( !str_cmp( name, "staff"     ) ) return ITEM_STAFF;
-        if ( !str_cmp( name, "weapon"    ) ) return ITEM_WEAPON;
-        if ( !str_cmp( name, "treasure"  ) ) return ITEM_TREASURE;
-        if ( !str_cmp( name, "armor"     ) ) return ITEM_ARMOR;
-        if ( !str_cmp( name, "potion"    ) ) return ITEM_POTION;
-        if ( !str_cmp( name, "furniture" ) ) return ITEM_FURNITURE;
-        if ( !str_cmp( name, "trash"     ) ) return ITEM_TRASH;
-        if ( !str_cmp( name, "container" ) ) return ITEM_CONTAINER;
-        if ( !str_cmp( name, "drink"     ) ) return ITEM_DRINK_CON;
-        if ( !str_cmp( name, "key"       ) ) return ITEM_KEY;
-        if ( !str_cmp( name, "food"      ) ) return ITEM_FOOD;
-        if ( !str_cmp( name, "money"     ) ) return ITEM_MONEY;
-        if ( !str_cmp( name, "boat"      ) ) return ITEM_BOAT;
-        if ( !str_cmp( name, "corpse"    ) ) return ITEM_CORPSE_NPC;
-        if ( !str_cmp( name, "fountain"  ) ) return ITEM_FOUNTAIN;
-        if ( !str_cmp( name, "pill"      ) ) return ITEM_PILL;
+        if ( !str_cmp( name, "light"                ) ) return ITEM_LIGHT;
+        if ( !str_cmp( name, "scroll"               ) ) return ITEM_SCROLL;
+        if ( !str_cmp( name, "wand"                 ) ) return ITEM_WAND;
+        if ( !str_cmp( name, "staff"                ) ) return ITEM_STAFF;
+        if ( !str_cmp( name, "weapon"               ) ) return ITEM_WEAPON;
+        if ( !str_cmp( name, "treasure"             ) ) return ITEM_TREASURE;
+        if ( !str_cmp( name, "armor"                ) ) return ITEM_ARMOR;
+        if ( !str_cmp( name, "potion"               ) ) return ITEM_POTION;
+        if ( !str_cmp( name, "furniture"            ) ) return ITEM_FURNITURE;
+        if ( !str_cmp( name, "trash"                ) ) return ITEM_TRASH;
+        if ( !str_cmp( name, "container"            ) ) return ITEM_CONTAINER;
+        if ( !str_cmp( name, "drink"                ) ) return ITEM_DRINK_CON;
+        if ( !str_cmp( name, "key"                  ) ) return ITEM_KEY;
+        if ( !str_cmp( name, "food"                 ) ) return ITEM_FOOD;
+        if ( !str_cmp( name, "money"                ) ) return ITEM_MONEY;
+        if ( !str_cmp( name, "boat"                 ) ) return ITEM_BOAT;
+        if ( !str_cmp( name, "corpse"               ) ) return ITEM_CORPSE_NPC;
+        if ( !str_cmp( name, "player corpse"        ) ) return ITEM_CORPSE_PC;
+        if ( !str_cmp( name, "fountain"             ) ) return ITEM_FOUNTAIN;
+        if ( !str_cmp( name, "pill"                 ) ) return ITEM_PILL;
+        if ( !str_cmp( name, "climbing equipment"   ) ) return ITEM_CLIMBING_EQ;
+        if ( !str_cmp( name, "paint"                ) ) return ITEM_PAINT;
+        if ( !str_cmp( name, "mob"                  ) ) return ITEM_MOB;
+        if ( !str_cmp( name, "anvil"                ) ) return ITEM_ANVIL;
+        if ( !str_cmp( name, "auction ticket"       ) ) return ITEM_AUCTION_TICKET;
+        if ( !str_cmp( name, "clan object"          ) ) return ITEM_CLAN_OBJECT;
+        if ( !str_cmp( name, "portal"               ) ) return ITEM_PORTAL;
         if ( !str_cmp( name, "poison powder"        ) ) return ITEM_POISON_POWDER;
+        if ( !str_cmp( name, "lockpick"             ) ) return ITEM_LOCK_PICK;
+        if ( !str_cmp( name, "instrument"           ) ) return ITEM_INSTRUMENT;
         if ( !str_cmp( name, "armourer's hammer"    ) ) return ITEM_ARMOURERS_HAMMER;
         if ( !str_cmp( name, "mithril"              ) ) return ITEM_MITHRIL;
         if ( !str_cmp( name, "whetstone"            ) ) return ITEM_WHETSTONE;
+        if ( !str_cmp( name, "crafting item"        ) ) return ITEM_CRAFT;
+        if ( !str_cmp( name, "spellcrafting item"   ) ) return ITEM_SPELLCRAFT ;
+        if ( !str_cmp( name, "turret module"        ) ) return ITEM_TURRET_MODULE;
+        if ( !str_cmp( name, "forge"                ) ) return ITEM_FORGE;
 
         return 0;
+
 }
 
 

--- a/server/src/handler.c
+++ b/server/src/handler.c
@@ -2896,39 +2896,46 @@ char* body_form_name (int vector)
  *
 */
 
-char* room_flag_name (int vector)
+char* room_flag_name (unsigned long int vector)
 {
-        if ( vector & ROOM_DARK             ) return "dark";
-        if ( vector & ROOM_NO_MOB           ) return "no_mob";
-        if ( vector & ROOM_INDOORS          ) return "indoors";
-        if ( vector & ROOM_CRAFT            ) return "craft";
-        if ( vector & ROOM_SPELLCRAFT       ) return "spellcraft";
-        if ( vector & ROOM_PRIVATE          ) return "private";
-        if ( vector & ROOM_SAFE             ) return "safe";
-        if ( vector & ROOM_SOLITARY         ) return "solitary";
-        if ( vector & ROOM_PET_SHOP         ) return "pet_shop";
-        if ( vector & ROOM_NO_RECALL        ) return "no_recall";
-        if ( vector & ROOM_CONE_OF_SILENCE  ) return "cone_of_silence";
-        if ( vector & ROOM_PLAYER_KILLER    ) return "player_killer";
-        if ( vector & ROOM_HEALING          ) return "healing";
-        if ( vector & ROOM_FREEZING         ) return "freezing";
-        if ( vector & ROOM_BURNING          ) return "burning";
-        if ( vector & ROOM_NO_MOUNT         ) return "no_mount";
-        return "";
+        switch (vector)
+        {
+                case ROOM_DARK:             return "dark";
+                case ROOM_NO_MOB:           return "no_mob";
+                case ROOM_INDOORS:          return "indoors";
+                case ROOM_CRAFT:            return "craft";
+                case ROOM_SPELLCRAFT:       return "spellcraft";
+                case ROOM_PRIVATE:          return "private";
+                case ROOM_SAFE:             return "safe";
+                case ROOM_SOLITARY:         return "solitary";
+                case ROOM_PET_SHOP:         return "pet_shop";
+                case ROOM_NO_RECALL:        return "no_recall";
+                case ROOM_CONE_OF_SILENCE:  return "cone_of_silence";
+                case ROOM_PLAYER_KILLER:    return "player_killer";
+                case ROOM_HEALING:          return "healing";
+                case ROOM_FREEZING:         return "freezing";
+                case ROOM_BURNING:          return "burning";
+                case ROOM_NO_MOUNT:         return "no_mount";
+                case ROOM_NO_DROP:          return "no_drop";
+
+                default: return "(unknown)";
+        }
 }
+
 
 /*
  * ASCII name for area flags, used in rstat --Owl 10/2/22
  *
 */
 
-char* area_flag_name (int vector)
+char* area_flag_name (unsigned long int vector)
 {
         if ( vector & AREA_FLAG_SCHOOL          ) return "school";
         if ( vector & AREA_FLAG_NO_QUEST        ) return "no_quest";
         if ( vector & AREA_FLAG_HIDDEN          ) return "hidden";
         if ( vector & AREA_FLAG_SAFE            ) return "safe";
         if ( vector & AREA_FLAG_NO_TELEPORT     ) return "no_teleport";
+        if ( vector & AREA_FLAG_NO_MAGIC        ) return "no_magic";
         return "none";
 }
 

--- a/server/src/magic.c
+++ b/server/src/magic.c
@@ -3027,7 +3027,8 @@ void spell_identify (int sn, int level, CHAR_DATA *ch, void *vo)
                 "a special clan artefact",                               "a magical portal",
                 "some poison powder",      "a lockpick",                 "a musical instrument",
                 "an armourer's hammer",    "some mithril",               "a whetstone",
-                "a crafting tool",         "a magical crafting tool",    "a turret module"
+                "a crafting tool",         "a magical crafting tool",    "a turret module",
+                "a forge"
         };
 
         const char* extras [MAX_BITS] =

--- a/server/src/magic.c
+++ b/server/src/magic.c
@@ -267,17 +267,6 @@ void do_cast( CHAR_DATA *ch, char *argument )
                 send_to_char( "That spell doesn't exist.\n\r", ch );
                 return;
         }
-        /*
-                Below code converts an int (e.g. 'sn') to a string and logs it.
-                Which is sometimes useful.
-
-                int length = snprintf( NULL, 0, "%d", sn );
-                char* mystr = malloc( length + 1 );
-                snprintf( mystr, length + 1, "%d", sn );
-                log_string(mystr);
-
-                -- Owl 23/09/18
-        */
 
         if (!IS_NPC(ch) && !CAN_DO(ch, sn))
         {
@@ -3735,6 +3724,25 @@ void spell_remove_curse( int sn, int level, CHAR_DATA *ch, void *vo )
 
         if (victim->fighting)
                 return;
+        
+        if ( is_affected( victim, gsn_curse ) )
+        {
+                affect_strip( victim, gsn_curse );
+                send_to_char( "Your curse has lifted.\n\r", victim );
+                yesno = 1;
+        }
+
+        if ( ch != victim && yesno )
+        {
+                send_to_char( "Ok.\n\r", ch );
+                check_group_bonus(ch);
+        }
+
+        if (IS_SET(victim->in_room->room_flags, ROOM_NO_DROP))
+	{
+	      send_to_char ("A powerful enchantment stops you attempting to remove cursed items here.\n\r", victim);
+	      return;
+	}
 
         for ( iWear = 0; iWear < MAX_WEAR; iWear ++ )
         {
@@ -3766,18 +3774,6 @@ void spell_remove_curse( int sn, int level, CHAR_DATA *ch, void *vo )
                 }
         }
 
-        if ( is_affected( victim, gsn_curse ) )
-        {
-                affect_strip( victim, gsn_curse );
-                send_to_char( "Your curse has lifted.\n\r", victim );
-                yesno = 1;
-        }
-
-        if ( ch != victim && yesno )
-        {
-                send_to_char( "Ok.\n\r", ch );
-                check_group_bonus(ch);
-        }
 
 }
 

--- a/server/src/merc.h
+++ b/server/src/merc.h
@@ -492,7 +492,7 @@ DECLARE_DO_FUN ( do_board );
 #define TYPE_STR                          2
 #define TYPE_WIZ                          3
 #define TYPE_NULL                         4
-#define MAX_ITEM_TYPE                    42
+#define MAX_ITEM_TYPE                    43
 #define MAX_WEAR                         22
 #define MAX_COLOR_LIST                   18
 
@@ -2002,7 +2002,7 @@ extern  WANTED_DATA *wanted_list_last;
  */
 #define ITEM_GLOW                       BIT_0
 #define ITEM_HUM                        BIT_1
-#define ITEM_EGO                        BIT_2   /* Item has special effects and powers; was ITEM_DARK */
+#define ITEM_EGO                        BIT_2   /* Item has special effects/powers; was ITEM_DARK */
 #define ITEM_ANTI_RANGER                BIT_3   /* Was ITEM_LOCK */
 #define ITEM_EVIL                       BIT_4
 #define ITEM_INVIS                      BIT_5

--- a/server/src/merc.h
+++ b/server/src/merc.h
@@ -2219,6 +2219,7 @@ extern  WANTED_DATA *wanted_list_last;
 #define ROOM_FREEZING                   BIT_17
 #define ROOM_BURNING                    BIT_18
 #define ROOM_NO_MOUNT                   BIT_19
+#define ROOM_NO_DROP                    BIT_63 /* Can't drop items in room, really just testing extended bitflags -- Owl 6/8/22 */
 
 
 /*
@@ -2308,6 +2309,7 @@ extern DIR_DATA directions [ MAX_DIR ];
 #define AREA_FLAG_HIDDEN        BIT_2   /* Area not seen on 'AREA' output */
 #define AREA_FLAG_SAFE          BIT_3   /* All rooms SAFE */
 #define AREA_FLAG_NO_TELEPORT   BIT_4   /* No rooms in area can be teleported into */
+#define AREA_FLAG_NO_MAGIC      BIT_40  /* Sets all rooms in area to cone_of_silence */
 
 
 /***************************************************************************
@@ -2807,27 +2809,27 @@ struct area_data
         RESET_DATA *            reset_first;
         RESET_DATA *            reset_last;
 
-        char *          author;
-        char *          name;
-        int             low_level;
-        int             high_level;
-        int             low_enforced;
-        int             high_enforced;
+        char *                  author;
+        char *                  name;
+        int                     low_level;
+        int                     high_level;
+        int                     low_enforced;
+        int                     high_enforced;
 
-        int             low_r_vnum;
-        int             hi_r_vnum;
-        int             low_o_vnum;
-        int             hi_o_vnum;
-        int             low_m_vnum;
-        int             hi_m_vnum;
+        int                     low_r_vnum;
+        int                     hi_r_vnum;
+        int                     low_o_vnum;
+        int                     hi_o_vnum;
+        int                     low_m_vnum;
+        int                     hi_m_vnum;
 
-        int             recall;
-        int             age;
-        int             nplayer;
+        int                     recall;
+        int                     age;
+        int                     nplayer;
 
-        int             container_reset_timer;  /* Poor little cpu; Gezhp */
-        int             area_flags;
-        int             exp_modifier;
+        int                     container_reset_timer;  /* Poor little cpu; Gezhp */
+        unsigned long int       area_flags;
+        int                     exp_modifier;
 };
 
 
@@ -2843,12 +2845,12 @@ struct room_index_data
         AREA_DATA *             area;
         EXIT_DATA *             exit [ 6 ];
 
-        char *  name;
-        char *  description;
-        int     vnum;
-        int     room_flags;
-        int     light;
-        int     sector_type;
+        char *                  name;
+        char *                  description;
+        int                     vnum;
+        unsigned long int       room_flags;
+        int                     light;
+        int                     sector_type;
 };
 
 
@@ -4550,8 +4552,8 @@ char *  extra_form_name                 args( ( int form ) );
 int     extra_form_int                        ( char *name );
 char *  extra_bit_name                  args( ( unsigned long int extra_flags ) );
 char *  body_form_name                  args( ( int vector ) );
-char *  room_flag_name                  args( ( int vector ) );
-char *  area_flag_name                  args( ( int vector ) );
+char *  room_flag_name                  args( ( unsigned long int vector ) );
+char *  area_flag_name                  args( ( unsigned long int vector ) );
 char *  wear_flag_name                  args( ( int vector ) );
 char *  wear_location_name              args( ( int wearloc_num ) );
 char *  weapon_damage_type_name         args( ( int dt_num) );

--- a/server/src/sft.c
+++ b/server/src/sft.c
@@ -884,9 +884,9 @@ void do_web (CHAR_DATA *ch, char *argument)
         if (number_percent() < chance)
         {
                 AFFECT_DATA af;
-                act ("You skillfully spin a sticky web around $N, trapping $M here!",
+                act ("You skilfully spin a sticky web around $N, trapping $M here!",
                      ch, NULL, victim, TO_CHAR);
-                act ("$n skillfully spins a sticky web around $N, trapping $M here!",
+                act ("$n skilfully spins a sticky web around $N, trapping $M here!",
                      ch, NULL, victim, TO_ROOM);
                 arena_commentary("$n traps $N in a sticky web.", ch, victim);
 

--- a/server/src/skill.c
+++ b/server/src/skill.c
@@ -170,7 +170,7 @@ void do_gouge (CHAR_DATA *ch, char *argument)
 
         if (victim == ch)
         {
-                send_to_char("You want to rip your own eyes out???\n\r", ch);
+                send_to_char("You want to rip your own eyes out?\n\r", ch);
                 return;
         }
 
@@ -209,7 +209,7 @@ void do_gouge (CHAR_DATA *ch, char *argument)
         if (number_percent() < chance)
         {
                 act ("You deftly lunge at $N's eyes, and gouge them out!", ch, NULL, victim, TO_CHAR);
-                act ("$n scratches your eyes -- you see red!", ch, NULL, victim, TO_VICT);
+                act ("$n scratches your eyes -- you see <124>red<0>!", ch, NULL, victim, TO_VICT);
                 act ("$n gouges $N's eyes out!", ch, NULL, victim, TO_NOTVICT);
                 arena_commentary("$n gouges out $N's eyes.", ch, victim);
 
@@ -265,7 +265,7 @@ void do_choke (CHAR_DATA *ch, char *argument)
 
         if (victim == ch)
         {
-                send_to_char("You want to choke yourself??\n\r", ch);
+                send_to_char("You want to choke yourself?\n\r", ch);
                 return;
         }
 
@@ -305,7 +305,7 @@ void do_choke (CHAR_DATA *ch, char *argument)
         {
                 act ("You circle around $N and apply a choker hold on them until they turn blue.",
                      ch, NULL, victim, TO_CHAR);
-                act ("$n begins to choke you.. you feel dizzy... you black out.",
+                act ("$n begins to choke you... you feel dizzy... you black out.",
                      ch, NULL, victim, TO_VICT);
                 act ("$n applies a choker hold on $N until they collapse, unconscious!",
                      ch, NULL, victim, TO_NOTVICT);
@@ -347,7 +347,7 @@ void do_battle_aura (CHAR_DATA *ch, char *argument)
 
         if (get_curr_int (ch) < 19 && get_curr_wis(ch) <19)
         {
-                send_to_char ("Your lack of intellect and concentration prevents this..\n\r", ch);
+                send_to_char ("Your lack of intellect and concentration prevents this...\n\r", ch);
                 return;
         }
 
@@ -375,7 +375,7 @@ void do_battle_aura (CHAR_DATA *ch, char *argument)
                 send_to_char("Concentrating intently to the point of shaking, you feel your body stiffen for battle.\n\r", ch);
         }
         else
-                send_to_char("You focus your mental energies but your concentration is lacking...\n\r", ch);
+                send_to_char("You focus your mental energies, but your concentration is lacking...\n\r", ch);
 
         return;
 }
@@ -418,7 +418,7 @@ void do_punch (CHAR_DATA *ch, char *argument)
 
         if (victim == ch)
         {
-                send_to_char("You want to knock yourself out??\n\r", ch);
+                send_to_char("You want to knock yourself out?\n\r", ch);
                 return;
         }
 
@@ -459,7 +459,7 @@ void do_dismount (CHAR_DATA *ch, char *argument)
         WAIT_STATE(ch, skill_table[gsn_mount].beats);
 
         act("You dismount $N.", ch, NULL, ch->mount, TO_CHAR);
-        act("$n skillfully dismounts $N.", ch, NULL, ch->mount, TO_NOTVICT);
+        act("$n skilfully dismounts $N.", ch, NULL, ch->mount, TO_NOTVICT);
         act("$n dismounts you.  Whew!", ch, NULL, ch->mount, TO_VICT);
 
         strip_mount(ch);
@@ -1953,8 +1953,8 @@ void do_forge (CHAR_DATA *ch, char *argument)
         if (in_c_room)
                 send_to_char("{CYour use of specialised crafting tools improves your forging!\n\r{x", ch);
 
-        act ("You skillfully enhance $P with $p!", ch, wobj, obj, TO_CHAR);
-        act ("$n skillfully enhances $P using $p!", ch, wobj, obj, TO_ROOM);
+        act ("You skilfully enhance $P with $p!", ch, wobj, obj, TO_CHAR);
+        act ("$n skilfully enhances $P using $p!", ch, wobj, obj, TO_ROOM);
 
         SET_BIT(obj->extra_flags, ITEM_FORGED);
 
@@ -2007,7 +2007,7 @@ void do_strengthen (CHAR_DATA *ch, char *argument)
 
         if (arg[0] == '\0')
         {
-                send_to_char("What are you trying to srengthen?\n\r", ch);
+                send_to_char("What are you trying to strengthen?\n\r", ch);
                 return;
         }
 
@@ -2050,7 +2050,7 @@ void do_strengthen (CHAR_DATA *ch, char *argument)
                                 || !str_cmp( wear_flag_name(next), "neck") 
                                 || !str_cmp( wear_flag_name(next), "about" ) )
                                 {
-                                        send_to_char("You cannot strengthen that type of armour..\n\r", ch);
+                                        send_to_char("You cannot strengthen that type of armour.\n\r", ch);
                                         return;        
                                 }
                         }
@@ -2118,8 +2118,8 @@ void do_strengthen (CHAR_DATA *ch, char *argument)
                 return;
         }
 
-        act ("You skillfully strengthen $P!", ch, NULL, obj, TO_CHAR);
-        act ("$n skillfully strengthens $P!", ch, NULL, obj, TO_ROOM);
+        act ("You skilfully strengthen $P!", ch, NULL, obj, TO_CHAR);
+        act ("$n skilfully strengthens $P!", ch, NULL, obj, TO_ROOM);
 
         SET_BIT(obj->extra_flags, ITEM_EGO);
         SET_BIT(obj->ego_flags, EGO_ITEM_STRENGTHEN);
@@ -3524,7 +3524,7 @@ void do_construct( CHAR_DATA *ch, char *arg )
 
         if (!found)
         {
-                send_to_char("You will need to find an Anvil.\n\r", ch);
+                send_to_char("You will need to find an anvil.\n\r", ch);
                 return;
         }
 
@@ -3558,7 +3558,7 @@ void do_construct( CHAR_DATA *ch, char *arg )
                 if ((!strcmp(blueprint_list[i].blueprint_name, "weaponchain") && number_percent() > ch->pcdata->learned[gsn_weaponchain]) )
                 {
                         send_to_char("You heat the forge, and ready your materials.\n\r", ch);
-                        send_to_char("You fumble.. your materials slip into the forge and are lost to the infernal heat.\n\r", ch);
+                        send_to_char("You fumble... your materials slip into the forge and are lost to the infernal heat.\n\r", ch);
                         act ("$n pounds $mself while creating $s armour!", ch, NULL, NULL, TO_ROOM);
                         smelted_to_char( blueprint_list[i].blueprint_cost[0], 
                                 blueprint_list[i].blueprint_cost[1],
@@ -3569,8 +3569,8 @@ void do_construct( CHAR_DATA *ch, char *arg )
                 }
                 if ((!strcmp(blueprint_list[i].blueprint_name, "shieldchain") && number_percent() > ch->pcdata->learned[gsn_shieldchain]) )
                 {
-                        send_to_char("You heat the forge, and ready your materials.\n\r", ch);
-                        send_to_char("You fumble.. your materials slip into the forge and are lost to the infernal heat.\n\r", ch);
+                        send_to_char("You heat the forge and ready your materials.\n\r", ch);
+                        send_to_char("You fumble... your materials slip into the forge and are lost to the infernal heat.\n\r", ch);
                         act ("$n pounds $mself while creating $s armour!", ch, NULL, NULL, TO_ROOM);
                         smelted_to_char( blueprint_list[i].blueprint_cost[0], 
                                 blueprint_list[i].blueprint_cost[1],
@@ -3585,7 +3585,7 @@ void do_construct( CHAR_DATA *ch, char *arg )
                 {               
                         SET_BIT(obj->extra_flags, ITEM_EGO);
                         SET_BIT(obj->ego_flags, blueprint_list[i].blueprint_ego);
-                        send_to_char( "You heat the forge, and ready your materials.\n\r", ch );
+                        send_to_char( "You heat the forge and ready your materials.\n\r", ch );
                         sprintf(buf, "Expertly you attach your {W%s{x to {W%s{x.", blueprint_list[i].blueprint_name, obj->name);
                         act(buf, ch, NULL, NULL, TO_CHAR);
 
@@ -3603,8 +3603,8 @@ void do_construct( CHAR_DATA *ch, char *arg )
 
         if ( number_percent() > ch->pcdata->learned[skill_lookup(blueprint_list[i].blueprint_name)] )
         {
-                send_to_char("You heat the forge, and ready your materials.\n\r", ch);
-                send_to_char("You fumble.. your materials slip into the forge and are lost to the infernal heat.\n\r", ch);
+                send_to_char("You heat the forge and ready your materials.\n\r", ch);
+                send_to_char("You fumble... your materials slip into the forge and are lost to the infernal heat.\n\r", ch);
                 act ("$n pounds $mself while creating $s armour!", ch, NULL, NULL, TO_ROOM);
                 smelted_to_char( blueprint_list[i].blueprint_cost[0], 
                         blueprint_list[i].blueprint_cost[1],
@@ -3626,7 +3626,7 @@ void do_construct( CHAR_DATA *ch, char *arg )
 
   
 
-        send_to_char( "You heat the forge, and ready your materials.\n\r", ch );
+        send_to_char( "You heat the forge and ready your materials.\n\r", ch );
         sprintf(buf, "Expertly you assemble your components to create {W%s{x.", blueprint_list[i].blueprint_desc);
         act(buf, ch, NULL, NULL, TO_CHAR);
 
@@ -3645,7 +3645,7 @@ void do_construct( CHAR_DATA *ch, char *arg )
 void do_empower (CHAR_DATA *ch, char *argument)
 {
 
-        char      arg1 [ MAX_INPUT_LENGTH ];
+        char     arg1 [ MAX_INPUT_LENGTH ];
         char     arg2 [ MAX_INPUT_LENGTH ];
         char     arg3 [ MAX_INPUT_LENGTH ];
         char     arg4 [ MAX_INPUT_LENGTH ];
@@ -3674,7 +3674,7 @@ void do_empower (CHAR_DATA *ch, char *argument)
         if( arg1[0] == '\0' || arg2[0] == '\0' || arg3[0] == '\0'  )
         {
                         send_to_char("What set do you wish to empower?\n\r", ch);
-                        send_to_char("Options <uncommon|rare|epic|legendary> <armour1> <armour2>.... etc\n", ch);
+                        send_to_char("Options <<uncommon|rare|epic|legendary> <<armour1> <<armour2>.... etc\n", ch);
                         send_to_char( "You can use ANY armour piece to create your set bonus\n\r", ch );
                 return;
         }
@@ -3693,7 +3693,7 @@ void do_empower (CHAR_DATA *ch, char *argument)
         {
                 if ( ( (obj = get_obj_carry(ch, arg2) ) == NULL ) || ( (obj2 = get_obj_carry(ch, arg3) ) == NULL ) ) 
                 {
-                        send_to_char( "You arent carrying that..\n\r",ch );
+                        send_to_char( "You aren't carrying that...\n\r",ch );
                         return;
                 }
   /*             
@@ -3999,7 +3999,7 @@ void do_counterbalance (CHAR_DATA *ch, char *argument)
         }
 */
 
-        sprintf( buf, "You counter balance %s.\n\r", obj->short_descr );
+        sprintf( buf, "You counterbalance %s.\n\r", obj->short_descr );
         send_to_char( buf, ch );
         sprintf( buf, "Its, a %d/%d split in weighting..\n\r", ch->pcdata->learned[gsn_counterbalance]/2, (100 - (ch->pcdata->learned[gsn_counterbalance]/2)) );
         send_to_char( buf, ch );
@@ -4051,7 +4051,7 @@ void do_trigger (CHAR_DATA *ch, char *argument)
 
         else if (!CAN_DO(ch, gsn_trigger))
         {
-                send_to_char("You cant trigger mechanisms.\n\r", ch);
+                send_to_char("You can't trigger mechanisms.\n\r", ch);
                 return;
         }
 
@@ -4091,7 +4091,7 @@ void do_trigger (CHAR_DATA *ch, char *argument)
 
         if (ch->position < POS_STANDING)
         {
-                send_to_char("Your not ready.\n\r", ch);
+                send_to_char("You're not ready.\n\r", ch);
                 return;
         }
 
@@ -4126,7 +4126,7 @@ void do_trigger (CHAR_DATA *ch, char *argument)
        
         if (!IS_SET(obj->ego_flags, EGO_ITEM_TURRET_MODULE) )
         {
-                send_to_char("How did that get in there - its not a turret module (report bug).\n\r", ch);
+                send_to_char("How did that get in there - it's not a turret module! (report bug).\n\r", ch);
                 return;
         }
         
@@ -4152,7 +4152,7 @@ void do_trigger (CHAR_DATA *ch, char *argument)
                 }
                 else
                 {
-                        act("The triggering mechanism collapses for the $p. Nothing happens..", ch, obj, NULL ,TO_CHAR);
+                        act("The triggering mechanism collapses for the $p. Nothing happens.", ch, obj, NULL ,TO_CHAR);
                         act("$n triggers $m $p, but nothing happens.", ch, obj, NULL, TO_ROOM);    
                 }
         }
@@ -4196,7 +4196,7 @@ void do_classify( CHAR_DATA *ch, char *arg )
             && obj->item_type != ITEM_PAINT
             && obj->item_type != ITEM_POTION )
         {
-                send_to_char( "Your herb lore doesn't describe that type of object.\n\r", ch );
+                send_to_char( "Your herb lore won't help you describe that type of object.\n\r", ch );
                 return;
         }
 

--- a/server/src/special.c
+++ b/server/src/special.c
@@ -2245,7 +2245,7 @@ bool spec_celestial_repairman (CHAR_DATA *ch)
                 {
                         REMOVE_BIT(pexit->exit_info, EX_BASHED);
                         act ("You repair the $d.", ch, NULL, pexit->keyword, TO_CHAR);
-                        act ("$n skillfully repairs the $d.", ch, NULL, pexit->keyword, TO_ROOM);
+                        act ("$n skilfully repairs the $d.", ch, NULL, pexit->keyword, TO_ROOM);
 
                         if ((to_room = pexit->to_room)
                             && (pexit_rev = to_room->exit[directions[door].reverse])


### PR DESCRIPTION
-AREA_FLAGS and ROOM_FLAGS now support the extended bit values.  ITEM_CURSED a bit more fleshed out. 

-ROOM_NO_DROP and AREA_NO_MAGIC added to text flags, but have also been implemented and behave more or less as they should.  Have been added to helper functions etc.

- rset() and rstat() support display and setting of extended bit values

-a bunch of area spelling etc fixes, and some obviously-cursed items given the ITEM_CURSED flag.