### PR TITLE
Upgrade gcc images from 4.9 to 9.5

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,8 +17,8 @@ services:
     # restart: always
 
   # Development environment
+  # Use the native platform, otherwise gdb can have problems tracing on some archs
   dev:
-    platform: linux/amd64
     image: dd4-dev
     build:
       context: .

--- a/docker/dev.Dockerfile
+++ b/docker/dev.Dockerfile
@@ -8,9 +8,9 @@
 #
 # See 'dev' and 'buid-dev' targets in the main Makefile.
 
-FROM gcc:4.9
+FROM gcc:9.5
 RUN apt-get update && \
-    apt-get -y install gdb vim less screen
+    DEBIAN_FRONTEND=noninteractive apt-get -y install gdb vim less screen
 COPY ./docker/dev_content/.screenrc /root/
 COPY ./docker/dev_content/.gdbinit /root/
 EXPOSE 8888

--- a/docker/server.Dockerfile
+++ b/docker/server.Dockerfile
@@ -1,10 +1,10 @@
 # Dockerfile for the DD4 MUD server.
 
-FROM gcc:4.9 AS build
+FROM gcc:9.5 AS build
 COPY ../server/src /dd4/src
 WORKDIR /dd4/src
 RUN make clean; \
-    make LINK=-static -j
+    make LINK=-static -j4
 
 FROM busybox:glibc AS server
 COPY --from=build /dd4/src/dd4 /dd4/bin/dd4

--- a/server/src/Makefile
+++ b/server/src/Makefile
@@ -3,9 +3,10 @@ PROF    =
 DEBUG   = -g
 NOCRYPT =
 LINK    =
-O_FLAGS = -O2 -m64
+O_FLAGS = -O2
 C_FLAGS = $(O_FLAGS) -pedantic-errors -Wall  \
-          -Wno-trigraphs -Wno-unused-result -Wno-overlength-strings -Wno-overflow  \
+          -Wno-trigraphs -Wno-unused-result -Wno-overlength-strings -Wno-overflow \
+          -Wno-format-overflow -Wno-stringop-truncation -Wno-stringop-overflow \
           $(DEBUG) $(PROF) $(NOCRYPT) -Dlinux -Dunix
 L_FLAGS = $(LINK) $(DEBUG) $(PROF) -lcrypt -lm
 


### PR DESCRIPTION
Version 4.9 gcc images were so old they now have trouble building. Use 9.5, built on more recent versions of Debian.

Tweak a few build files to make it all build cleanly.