### PR TITLE
Write time and backtrace in last command debug

### DIFF
--- a/server/src/Makefile
+++ b/server/src/Makefile
@@ -2,7 +2,7 @@ CC      = gcc
 PROF    =
 DEBUG   = -gdwarf-2
 NOCRYPT =
-LINK    =
+LINK    = -rdynamic
 O_FLAGS = -O2
 C_FLAGS = $(O_FLAGS) -pedantic-errors -Wall  \
           -Wno-trigraphs -Wno-unused-result -Wno-overlength-strings -Wno-overflow \


### PR DESCRIPTION
Provide a little more context in the last command log.

    Sun Oct  8 20:00:26 2023
    Command 'wizhelp'
    Issued by 'Gezhp' (player) at room 72
    Master is '(null)'
    Function: leaving update_handler
    Backtrace:
    ../src/dd4(write_last_command+0xdc)[0x44e2d4]
    ../src/dd4(alloc_mem+0x40)[0x4575c0]
    ../src/dd4(str_dup+0x4c)[0x45764c]
    ../src/dd4(send_to_char+0xac)[0x44fc74]
    ../src/dd4(interpret+0x264)[0x474034]
    ../src/dd4(game_loop_unix+0x638)[0x453b30]
    ../src/dd4(main+0x104)[0x41e8c4]
    /lib/aarch64-linux-gnu/libc.so.6(__libc_start_main+0xe8)[0xffff8e537e18]
    ../src/dd4[0x41e974]