### PR TITLE
Added do_empty, fountain stuff

### DIFF
--- a/server/area/citie.are
+++ b/server/area/citie.are
@@ -1229,7 +1229,7 @@ drink skin~
 a drink skin~
 A drink skin lies here.~
 ~
-25 1 1
+25 1|64 1
 0~ 0~ 0~ 0~
 5 0 0
 #23572

--- a/server/area/darkwood.are
+++ b/server/area/darkwood.are
@@ -484,7 +484,7 @@ the lagoon~
 ~
 ~
 25 0 0
-0~ 1~ 6~ 11~
+0~ 1~ 0~ 0~
 5 0 0
 E
 lagoon water~

--- a/server/area/deathdun.are
+++ b/server/area/deathdun.are
@@ -1856,7 +1856,7 @@ a fountain carved in the shape of a cherub~
 A fountain carved in the shape of a cherub rests near the west wall.~
 ~
 25 0 0
-0~ 0~ 0~ 1~
+0~ 0~ 0~ 0~
 10000 0 0
 E
 fountain~

--- a/server/area/demondium.are
+++ b/server/area/demondium.are
@@ -2017,7 +2017,7 @@ a water statue~
 A small statue sits here with water flowing continually from it.~
 ~
 25 1|64 1
-0~ 1~ 6~ 11~
+0~ 1~ 0~ 11~
 1 0 0
 #21568
 vial blood~

--- a/server/area/descent.are
+++ b/server/area/descent.are
@@ -214,7 +214,7 @@ blood~
 the blood from the fountain~
 The blood in the fountain gurgles merrily.
 ~
-You see gallons and gallons of thick red blood gurgling in the fountian.
+You see gallons and gallons of thick red blood gurgling in the fountain.
 ~
 1|2|32|64 512 -950 S
 25 2 2 1d1+30000 1d8+32

--- a/server/area/deserts.are
+++ b/server/area/deserts.are
@@ -575,7 +575,7 @@ the spring~
 The spring gurgles merrily northwards, its sparkling clear waters offering relief from the heat...~
 ~
 25 0 0
-0~ 1~ 6~ 11~
+0~ 1~ 0~ 0~
 1000 0 0
 #13631
 clear bottle~

--- a/server/area/draagdim.are
+++ b/server/area/draagdim.are
@@ -2042,7 +2042,7 @@ a sulphurous pool~
 Acrid steam wafts from a churning, sulphuric hot pool.~
 ~
 25 16 0
-~ ~ ~ ~
+0~ 0~ 7~ 1~
 0 0 0
 E
 pool sulphurous~

--- a/server/area/draagdim_highqtr.are
+++ b/server/area/draagdim_highqtr.are
@@ -956,7 +956,7 @@ a sulfurous pool~
 Acrid steam wafts from a churning, sulfuric hot pool.~
 ~
 25 16 0
-0~ 0~ 0~ 0~
+0~ 0~ 7~ 1~
 0 0 0
 E
 pool sulfurous~

--- a/server/area/east_of_draagdim.are
+++ b/server/area/east_of_draagdim.are
@@ -220,12 +220,12 @@ road to waylay travellers who stray too far east.
 
 #OBJECTS
 #700
-stone well~
+stone well murky~
 a stone well~
 Murky water can be seen within a small stone well.~
 ~
 25 0 0
-~ ~ ~ ~
+0~ 0~ 0~ 1~
 10000 0 0
 
 #701

--- a/server/area/helpfile.are
+++ b/server/area/helpfile.are
@@ -1185,6 +1185,18 @@ AUTOEXIT set, you will automatically see the visible exits whenever you
 walk into a room.
 ~
 
+0 EMPTY~
+Syntax: empty <<object>
+
+EMPTY allows you to empty the contents of various sorts of objects, usually
+into the room you are standing in.  You may attempt to EMPTY item storage
+objects, drink containers, and corpses (player or NPC).
+
+You can't EMPTY a container's contents if you can't see them, and you must
+have at least one inventory slot free to work with the item or items you're
+pulling out.
+~
+
 0 DROP GET GIVE PUT TAKE~
 Syntax: drop <<object>
 Syntax: drop <<amount> <<coin type>

--- a/server/area/hood.are
+++ b/server/area/hood.are
@@ -234,7 +234,7 @@ A handful of loose change such as someone might carry on their person.
 #2114
 single gold coin~
 a single gold coin~
-A single gold ocin sits on the floor at your feet.~
+A single gold coin sits on the floor at your feet.~
 ~
 20 1 1
 0~ 0~ 1~ 0~

--- a/server/area/leanon.are
+++ b/server/area/leanon.are
@@ -105,7 +105,7 @@ a creek~
 A creek trickles quietly.~
 ~
 25 0 8192
-0~ 1~ 6~ 11~
+0~ 1~ 0~ 0~
 5 0 0
 #18201
 billy~
@@ -113,7 +113,7 @@ a billy~
 There is a fire crackling with a billy boiling away.~
 ~
 25 0 8192
-0~ 1~ 6~ 11~
+0~ 1~ 11~ 0~
 5 0 0
 #18202
 pitch fork pitchfork~

--- a/server/area/limbo.are
+++ b/server/area/limbo.are
@@ -373,7 +373,7 @@ A
 #2
 coin~
 a coin~
-One miserable coin.~
+One miserable coin is here.~
 ~
 20 0 1
 1~ ~ ~ ~
@@ -381,7 +381,7 @@ One miserable coin.~
 #3
 coins~
 some coins~
-A pile of coins.~
+A pile of coins is here.~
 ~
 20 0 1
 0~ 0~ 0~ 0~

--- a/server/area/mrinthas.are
+++ b/server/area/mrinthas.are
@@ -331,7 +331,7 @@ a font~
 A font containing what appears to be holy water.~
 ~
 25 0 0
-~ ~ ~ ~
+0~ 0~ 0~ 0~
 1000 0 0
 #13015
 Robe Robes~

--- a/server/area/quake.are
+++ b/server/area/quake.are
@@ -964,7 +964,7 @@ a fountain~
 A purple fountain gushes forth here.~
 ~
 25 0 0
-~ ~ ~ ~
+0~ 0~ 0~ 0~
 500 0 0
 E
 fountain~

--- a/server/area/sahuagin_market.are
+++ b/server/area/sahuagin_market.are
@@ -3296,7 +3296,7 @@ A workbench for magical crafting stands here.~
 1000 0 0
 #27345
 large black cube ~
-a large black cube ~
+a large black cube~
 A large black cube pulses with magical energy.~
 ~
 15 2097152 1|4|512 -1 2 0

--- a/server/area/vampcat.are
+++ b/server/area/vampcat.are
@@ -3606,7 +3606,7 @@ a trough~
 A water trough stands here at the rear of the horse box.~
 ~
 25 0 8192
-0~ 1~ 6~ 11~
+0~ 1~ 0~ 0~
 300 0 0
 E
 trough water~

--- a/server/area/vampcat4.are
+++ b/server/area/vampcat4.are
@@ -2828,6 +2828,20 @@ A shapeless grey garment lies on the floor at your feet.~
 9 0 1|8
 0~ 0~ 0~ 0~
 2 0 0
+#25724
+golden fountain blood~
+a small golden fountain~
+<227>A small golden fountain brims with what appears to be blood.<0>~
+~
+25 16|64|2305843009213693952 0
+0~ 0~ 13~ 0~
+150 0 0
+E
+golden fountain blood~
+The thick pool of blood burbles gently with what, on closer inspection, is
+definitely blood.  You can't see where the blood is coming from or draining to.
+You suspect magic.  Black magic.
+~
 
 #0
 
@@ -7740,6 +7754,8 @@ G 1 25716 100
 G 1 25719 100
 O 1 25718 100 25783         a crystal coffin to Overseer's Living Quarters
 P 1 25720 100 25718         a pile of gold and gems to container casket coffin crystal
+*
+O 1 25724 100 25784         blood fountain to Overseer's Living Quarters
 *
 O 1 25721 100 25771
 O 1 25722 100 25772

--- a/server/log/last_command.txt
+++ b/server/log/last_command.txt
@@ -1,0 +1,20 @@
+Fri Dec  8 22:51:06 2023
+Command 'empty sack'
+Issued by 'Owl' (player) at room 78
+Master is '(null)'
+Function: leaving update_handler
+Backtrace:
+../src/dd4(write_last_command+0xe7)[0x451477]
+/lib/x86_64-linux-gnu/libc.so.6(+0x38d60)[0x7fd941b75d60]
+../src/dd4(can_see_obj+0x0)[0x4739d0]
+../src/dd4[0x4550f1]
+../src/dd4(do_empty+0x18d)[0x4374bd]
+../src/dd4(interpret+0x371)[0x4772f1]
+../src/dd4(game_loop_unix+0x619)[0x457289]
+../src/dd4(main+0xe0)[0x41f5f0]
+/lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0xea)[0x7fd941b60d0a]
+../src/dd4(_start+0x2a)[0x41f69a]
+
+62d0a]
+/dd4-dev/src/dd4(_start+0x2a)[0x41f69a]
+

--- a/server/src/act_wiz.c
+++ b/server/src/act_wiz.c
@@ -1046,13 +1046,14 @@ void do_ostat( CHAR_DATA *ch, char *argument )
         sprintf( buf, "Type: {G%s{x [{W%d{x] ",item_type_name( obj ), obj->item_type);
         strcat( buf1, buf );
 
-        /* Show liquid type if drink container. -- Owl 1/7/22 */
-        if (obj->item_type == 17)
+        /* Show liquid type if drink container or fountain. -- Owl 1/7/22 & 9/12/23 */
+        if (obj->item_type == 17 || obj->item_type == 25)
         {
-                sprintf( buf, "\n\rLiquid: {G%s{x [{W%d{x]  Colour: {G%s{x",
+                sprintf( buf, "\n\rLiquid: {G%s{x [{W%d{x]  Colour: {G%s{x  Poisoned: {G%s{x",
                         liq_table[obj->value[2]].liq_name,
                         obj->value[2],
-                        liq_table[obj->value[2]].liq_color);
+                        liq_table[obj->value[2]].liq_color,
+                        (obj->value[3] != 0 ? "{MYes{x" : "{GNo{x"));
                 strcat( buf1, buf );
         }
 

--- a/server/src/interp.c
+++ b/server/src/interp.c
@@ -178,6 +178,7 @@ const struct cmd_type cmd_table [] =
         { "drop",       do_drop,        POS_RESTING,     0,  LOG_NORMAL },
         { "deploy",     do_deploy,      POS_RESTING,     0,  LOG_NORMAL },
         { "eat",        do_eat,         POS_RESTING,     0,  LOG_NORMAL },
+        { "empty",      do_empty,       POS_RESTING,     0,  LOG_NORMAL },
         { "enter",      do_enter,       POS_STANDING,    0,  LOG_NORMAL },
         { "feed",       do_feed,        POS_FIGHTING,    0,  LOG_NORMAL },
         { "fill",       do_fill,        POS_RESTING,     0,  LOG_NORMAL },

--- a/server/src/merc.h
+++ b/server/src/merc.h
@@ -321,9 +321,9 @@ bool    has_tranquility ( CHAR_DATA *ch );
 #define LEVEL_IMMORTAL              L_BUI
 #define LEVEL_HERO                ( LEVEL_IMMORTAL - 1 )
 
-#define MAX_SKILL                   571     /* +1 mppeace 8/10/23 */
-#define MAX_PRE_REQ                 1398    /* 1 reforge - Brutus 1/1/23 */
-#define MAX_SPELL_GROUP             452    /* +1 reforge Brutus 1/1/23 */
+#define MAX_SKILL                   572     /* +1 do_empty 9/12/23 */
+#define MAX_PRE_REQ                 1398    /* +1 reforge - Brutus 1/1/23 */
+#define MAX_SPELL_GROUP             452     /* +1 reforge Brutus 1/1/23 */
 #define MAX_GROUPS                  61      /* +1 for runecaster - Brutus Aug 2022 */
 #define MAX_FORM_SKILL              74      /* 73 + 1 for 'swallow' | for form skill table */
 #define MAX_VAMPIRE_GAG             27      /* 26 + 1 for 'swallow' | ugly vampire/werewolf hack */
@@ -4042,6 +4042,7 @@ extern PKSCORE_DATA             pkscore_table [ PKSCORE_TABLE_LENGTH ];
 extern INFAMY_TABLE             infamy_table [ INFAMY_TABLE_LENGTH ];
 
 
+
 /*
  * Command functions.
  * Defined in act_*.c (mostly).
@@ -4139,6 +4140,7 @@ DECLARE_DO_FUN( do_east                         );
 DECLARE_DO_FUN( do_eat                          );
 DECLARE_DO_FUN( do_echo                         );
 DECLARE_DO_FUN( do_emote                        );
+DECLARE_DO_FUN( do_empty                        );
 DECLARE_DO_FUN( do_enter                        );      /* enter for portal.. - Brutus */
 DECLARE_DO_FUN( do_engrave                      );
 DECLARE_DO_FUN( do_empower                      );      /* smithy Brutus Jul 2022 */


### PR DESCRIPTION
- Added do_empty.  Can now empty drink and storage containers, and corpses.
- Fountains can now contain any liquid and be poisoned (like drinks).  Changes to do_drink etc to make this work.
- Added information to ostat so imms can see if fountains are poisoned and what liquid they produce at a glance
- Area tweaks (mostly fixing fountains so they behave properly with changes)