### PR TITLE
Area fixes

### DIFF
--- a/server/area/vampcat4.are
+++ b/server/area/vampcat4.are
@@ -1786,7 +1786,7 @@ A small purple stone hovers in the air above the ground.~
 ~
 18 1|2|64|274877906944 1|32768
 0~ 0~ 0~ 0~
-1 274877906944 0
+1 0 0
 A
 12 80
 E


### PR DESCRIPTION
Bad cost value left in vampcat4. Made it zero, as similar items are defined.